### PR TITLE
Add spec suite gate to PR CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,3 +69,33 @@ jobs:
       - run: uv sync --extra dev
       - run: uv run pytest tests/ -v --mcp-cmd "biomcp serve"
       - run: uv run mkdocs build --strict
+
+  spec:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache protoc
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.tool_cache }}/protoc
+          key: protoc-${{ runner.os }}-${{ runner.arch }}-v28.3
+
+      - uses: arduino/setup-protoc@v3
+        continue-on-error: true
+        with:
+          version: "28.3"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - uses: astral-sh/setup-uv@v4
+
+      # Build the release binary first so make spec exercises target/release/biomcp,
+      # not a stale editable install from .venv/bin.
+      - run: cargo build --release --locked
+      - run: make spec

--- a/analysis/technical/overview.md
+++ b/analysis/technical/overview.md
@@ -81,12 +81,13 @@ share one limiter budget and one Streamable HTTP `/mcp` surface.
 2. Commit and push to `main`
 3. Cut a GitHub release with a semver tag
 4. GitHub Actions validates and publishes:
-   - CI (`.github/workflows/ci.yml`) runs four parallel jobs: `check`
+   - CI (`.github/workflows/ci.yml`) runs five parallel jobs: `check`
      (`cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test`),
      `version-sync` (`bash scripts/check-version-sync.sh`),
      `climb-hygiene` (`bash scripts/check-no-climb-tracked.sh`), and
      `contracts` (`uv sync --extra dev`, `uv run pytest tests/ -v --mcp-cmd "biomcp serve"`,
-     `uv run mkdocs build --strict`).
+     `uv run mkdocs build --strict`), and `spec` (`cargo build --release --locked`,
+     then `make spec`).
    - Release validation runs the Rust checks again, then
      `uv run pytest tests/ -v --mcp-cmd "biomcp serve"` and
      `uv run mkdocs build --strict`.
@@ -104,7 +105,7 @@ BioMCP has three verification layers:
 
 ### 1. GitHub Workflows
 
-CI (`.github/workflows/ci.yml`) runs four parallel jobs: `check` (`cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test`), `version-sync` (`bash scripts/check-version-sync.sh`), `climb-hygiene` (`bash scripts/check-no-climb-tracked.sh`), and `contracts` (`uv sync --extra dev`, `uv run pytest tests/ -v --mcp-cmd "biomcp serve"`, `uv run mkdocs build --strict`).
+CI (`.github/workflows/ci.yml`) runs five parallel jobs: `check` (`cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test`), `version-sync` (`bash scripts/check-version-sync.sh`), `climb-hygiene` (`bash scripts/check-no-climb-tracked.sh`), `contracts` (`uv sync --extra dev`, `uv run pytest tests/ -v --mcp-cmd "biomcp serve"`, `uv run mkdocs build --strict`), and `spec` (`cargo build --release --locked`, then `make spec`).
 Contract smoke checks run in `.github/workflows/contracts.yml` on a schedule
 and by manual dispatch via `bash scripts/contract-smoke.sh`.
 release validation runs `pytest tests/` and `mkdocs build --strict` after the
@@ -117,7 +118,10 @@ exercises CLI output at the command level using stable structural markers
 (headers, table columns, query echoes) rather than brittle upstream data
 values.
 
-The spec suite is repo-local executable documentation; no GitHub workflow currently runs `make spec`.
+PR CI now runs `make spec` via the `spec` job in `.github/workflows/ci.yml`.
+That job builds the release binary first, then relies on the Makefile's
+`target/release`-first `PATH` handling so specs do not accidentally execute a
+stale `.venv/bin/biomcp`.
 
 Run locally with `make spec`.
 

--- a/tests/test_upstream_planning_analysis_docs.py
+++ b/tests/test_upstream_planning_analysis_docs.py
@@ -127,12 +127,13 @@ def test_technical_and_ux_docs_match_current_cli_and_workflow_contracts() -> Non
     technical = _read_repo("analysis/technical/overview.md")
     ux = _read_repo("analysis/ux/cli-reference.md")
 
-    assert "CI (`.github/workflows/ci.yml`) runs four parallel jobs" in technical
+    assert "CI (`.github/workflows/ci.yml`) runs five parallel jobs" in technical
     assert "`check` (`cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test`)" in technical
     assert "`version-sync` (`bash scripts/check-version-sync.sh`)" in technical
     assert "`climb-hygiene` (`bash scripts/check-no-climb-tracked.sh`)" in technical
     assert '`contracts` (`uv sync --extra dev`, `uv run pytest tests/ -v --mcp-cmd "biomcp serve"`, `uv run mkdocs build --strict`)' in technical
-    assert "The spec suite is repo-local executable documentation; no GitHub workflow currently runs `make spec`." in technical
+    assert "`spec` (`cargo build --release --locked`, then `make spec`)" in technical
+    assert "PR CI now runs `make spec` via the `spec` job in `.github/workflows/ci.yml`." in technical
     assert "Contract smoke checks run in `.github/workflows/contracts.yml`" in technical
     assert "release validation runs `pytest tests/` and `mkdocs build --strict`" in technical
     assert "Streamable HTTP" in technical
@@ -170,13 +171,24 @@ def test_pull_request_contract_gate_matches_release_validation() -> None:
     ]
 
     ci_contracts = _workflow_job_block(ci, "contracts")
+    ci_spec = _workflow_job_block(ci, "spec")
     ci_version_sync = _workflow_job_block(ci, "version-sync")
     ci_climb_hygiene = _workflow_job_block(ci, "climb-hygiene")
     release_validate = _workflow_job_block(release, "validate")
 
     assert 'python-version: "3.12"' in ci_contracts
+    assert 'python-version: "3.12"' in ci_spec
     assert 'python-version: "3.12"' in release_validate
     assert _workflow_run_steps(ci_contracts) == expected_contract_runs
+    assert "- uses: actions/checkout@v4" in ci_spec
+    assert "uses: arduino/setup-protoc@v3" in ci_spec
+    assert "uses: dtolnay/rust-toolchain@stable" in ci_spec
+    assert "uses: actions/setup-python@v5" in ci_spec
+    assert "uses: astral-sh/setup-uv@v4" in ci_spec
+    assert _workflow_run_steps(ci_spec) == [
+        "cargo build --release --locked",
+        "make spec",
+    ]
     assert _workflow_run_steps(release_validate)[-3:] == expected_contract_runs
     assert "- uses: actions/checkout@v4" in ci_version_sync
     assert _workflow_run_steps(ci_version_sync) == [


### PR DESCRIPTION
## Summary

- Adds a new `spec` job to `.github/workflows/ci.yml` that builds `target/release/biomcp` via `cargo build --release --locked` and then runs `make spec`
- Removes the stale statement in `analysis/technical/overview.md` that said no GitHub workflow runs `make spec`; updates the doc to describe the five-job PR CI surface
- Extends `tests/test_upstream_planning_analysis_docs.py` with assertions that guard the five-job CI inventory and the exact `spec` job run steps, so CI docs and workflow stay in sync

## Why

The BioMCP spec suite is the repo's executable CLI contract documentation, but no PR CI job ran it. A failing spec could go undetected until a manual local run. This change closes that gap so spec regressions fail in CI before review.

## Notes

- The Makefile already prepends `target/release` to `PATH` so `make spec` uses the freshly built binary rather than the potentially stale editable `.venv/bin/biomcp` install
- Tests gated on `OPENFDA_API_KEY` are skipped in CI via `spec/conftest.py` — no secrets required in the new job