### PR TITLE
Move age filter to cheap CTGov path and add traversal page cap

### DIFF
--- a/spec/04-trial.md
+++ b/spec/04-trial.md
@@ -34,9 +34,9 @@ echo "$out" | mustmatch like "|NCT ID|Title|Status|Phase|Conditions|"
 
 ## Age Filter Count Stability
 
-Age-filtered count-only search must report the same total regardless of display
-limit. This guards the CTGov post-filter pagination bug where `Total:` changed
-with `--limit`.
+Age-only count-only search must stay on the cheap CTGov total path regardless
+of display limit. This guards the regression where age was incorrectly grouped
+with expensive detail-verified post-filters and `Total:` changed with `--limit`.
 
 ```bash
 t10="$("$(git rev-parse --show-toplevel)/target/release/biomcp" search trial -c melanoma -s recruiting --age 51 --limit 10 --count-only | sed -n 's/^Total: //p')"
@@ -46,6 +46,19 @@ test -n "$t10"
 test "$t10" = "$t20"
 test "$t20" = "$t50"
 ```
+
+## Expensive Count Traversal Cap
+
+When facility or eligibility verification forces the expensive detail-fetch
+path, `--count-only` must stop at the traversal cap and report an unknown total
+instead of a misleading lower bound.
+
+Contract note:
+Text output is `Total: unknown (traversal limit reached)` and JSON output is
+`{"total": null}` when the traversal cap is hit. This is regression-covered in
+`src/entities/trial.rs` unit tests because a real live-spec query broad enough
+to exhaust the cap would require large-scale per-study detail fetches and is
+not stable enough for the executable spec suite.
 
 ## Fractional Age Filter
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -4201,13 +4201,16 @@ pub async fn run(cli: Cli) -> anyhow::Result<String> {
                         if cli.json {
                             #[derive(serde::Serialize)]
                             struct TrialCountOnlyJson {
-                                total: usize,
+                                total: Option<usize>,
                             }
                             return Ok(crate::render::json::to_pretty(&TrialCountOnlyJson {
                                 total,
                             })?);
                         }
-                        return Ok(format!("Total: {total}"));
+                        return Ok(match total {
+                            Some(total) => format!("Total: {total}"),
+                            None => "Total: unknown (traversal limit reached)".to_string(),
+                        });
                     }
                     let page = crate::entities::trial::search_page(
                         &filters,

--- a/src/entities/trial.rs
+++ b/src/entities/trial.rs
@@ -1384,7 +1384,7 @@ struct CtGovSearchContext {
     agg_filters: Option<String>,
     eligibility_keywords: Vec<String>,
     facility_geo_verification: Option<(String, f64, f64, u32)>,
-    uses_post_filters: bool,
+    uses_expensive_post_filters: bool,
     has_explicit_status: bool,
 }
 
@@ -1489,9 +1489,8 @@ fn prepare_ctgov_search_context(
         .map(|(((facility_name, lat), lon), distance)| {
             (facility_name.to_string(), lat, lon, distance)
         });
-    let uses_post_filters = facility_geo_verification.is_some()
-        || !eligibility_keywords.is_empty()
-        || filters.age.is_some();
+    let uses_expensive_post_filters =
+        facility_geo_verification.is_some() || !eligibility_keywords.is_empty();
 
     Ok(CtGovSearchContext {
         normalized_status: normalized.normalized_status.clone(),
@@ -1500,7 +1499,7 @@ fn prepare_ctgov_search_context(
         agg_filters,
         eligibility_keywords,
         facility_geo_verification,
-        uses_post_filters,
+        uses_expensive_post_filters,
         has_explicit_status,
     })
 }
@@ -1585,7 +1584,7 @@ async fn search_page_with_ctgov_client(
         }
 
         studies = apply_ctgov_post_filters(client, filters, &context, studies).await;
-        if context.uses_post_filters {
+        if context.uses_expensive_post_filters {
             verified_total = verified_total.saturating_add(studies.len());
         }
 
@@ -1645,7 +1644,7 @@ async fn search_page_with_ctgov_client(
     }
 
     rows.truncate(limit);
-    let returned_total = if context.uses_post_filters {
+    let returned_total = if context.uses_expensive_post_filters {
         exhausted.then_some(verified_total)
     } else {
         total.or_else(|| Some(offset.saturating_add(rows.len())))
@@ -1657,8 +1656,9 @@ async fn search_page_with_ctgov_client(
 async fn count_all_with_ctgov_client(
     client: &ClinicalTrialsClient,
     filters: &TrialSearchFilters,
-) -> Result<usize, BioMcpError> {
+) -> Result<Option<usize>, BioMcpError> {
     const COUNT_PAGE_SIZE: usize = 1000;
+    const COUNT_TRAVERSAL_PAGE_CAP: usize = 50;
 
     if !matches!(filters.source, TrialSource::ClinicalTrialsGov) {
         return Err(BioMcpError::InvalidArgument(
@@ -1669,7 +1669,7 @@ async fn count_all_with_ctgov_client(
     let normalized = validate_trial_search(filters)?;
     let context = prepare_ctgov_search_context(filters, &normalized)?;
 
-    if !context.uses_post_filters {
+    if !context.uses_expensive_post_filters {
         let resp = client
             .search(&CtGovSearchParams {
                 condition: filters.condition.clone(),
@@ -1689,13 +1689,18 @@ async fn count_all_with_ctgov_client(
                 distance_miles: filters.distance,
             })
             .await?;
-        return Ok(resp.total_count.unwrap_or(0) as usize);
+        return Ok(Some(resp.total_count.unwrap_or(0) as usize));
     }
 
     let mut verified_total = 0usize;
     let mut page_token: Option<String> = None;
+    let mut page_count = 0usize;
 
     loop {
+        if page_count >= COUNT_TRAVERSAL_PAGE_CAP {
+            return Ok(None);
+        }
+
         let resp = client
             .search(&CtGovSearchParams {
                 condition: filters.condition.clone(),
@@ -1715,6 +1720,7 @@ async fn count_all_with_ctgov_client(
                 distance_miles: filters.distance,
             })
             .await?;
+        page_count += 1;
 
         let next_page_token = resp.next_page_token;
         let studies = apply_ctgov_post_filters(client, filters, &context, resp.studies).await;
@@ -1726,10 +1732,10 @@ async fn count_all_with_ctgov_client(
         page_token = next_page_token;
     }
 
-    Ok(verified_total)
+    Ok(Some(verified_total))
 }
 
-pub async fn count_all(filters: &TrialSearchFilters) -> Result<usize, BioMcpError> {
+pub async fn count_all(filters: &TrialSearchFilters) -> Result<Option<usize>, BioMcpError> {
     match filters.source {
         TrialSource::ClinicalTrialsGov => {
             let client = ClinicalTrialsClient::new()?;
@@ -1737,7 +1743,7 @@ pub async fn count_all(filters: &TrialSearchFilters) -> Result<usize, BioMcpErro
         }
         TrialSource::NciCts => {
             let page = search_page(filters, 1, 0, None).await?;
-            Ok(page.total.unwrap_or(page.results.len()))
+            Ok(Some(page.total.unwrap_or(page.results.len())))
         }
     }
 }
@@ -2504,6 +2510,19 @@ AREA[OfficialTitle](\"G12D\") OR AREA[BriefSummary](\"G12D\") OR AREA[Keyword](\
         })
     }
 
+    fn ctgov_eligibility_detail_fixture(nct_id: &str, criteria: &str) -> serde_json::Value {
+        json!({
+            "protocolSection": {
+                "identificationModule": {
+                    "nctId": nct_id
+                },
+                "eligibilityModule": {
+                    "eligibilityCriteria": criteria
+                }
+            }
+        })
+    }
+
     fn age_filtered_ctgov_filters() -> TrialSearchFilters {
         TrialSearchFilters {
             condition: Some("melanoma".into()),
@@ -2531,7 +2550,7 @@ AREA[OfficialTitle](\"G12D\") OR AREA[BriefSummary](\"G12D\") OR AREA[Keyword](\
     }
 
     #[tokio::test]
-    async fn age_filter_total_semantics_do_not_change_with_limit() {
+    async fn age_filter_uses_native_total_semantics_across_limits() {
         let server = MockServer::start().await;
         let client = ClinicalTrialsClient::new_for_test(server.uri()).expect("client");
 
@@ -2587,21 +2606,21 @@ AREA[OfficialTitle](\"G12D\") OR AREA[BriefSummary](\"G12D\") OR AREA[Keyword](\
                 .await
                 .expect("page")
                 .total,
-            None
+            Some(200)
         );
         assert_eq!(
             search_page_with_ctgov_client(&client, &filters, 20, 0, None)
                 .await
                 .expect("page")
                 .total,
-            None
+            Some(200)
         );
         assert_eq!(
             search_page_with_ctgov_client(&client, &filters, 50, 0, None)
                 .await
                 .expect("page")
                 .total,
-            None
+            Some(200)
         );
     }
 
@@ -2636,7 +2655,7 @@ AREA[OfficialTitle](\"G12D\") OR AREA[BriefSummary](\"G12D\") OR AREA[Keyword](\
     }
 
     #[tokio::test]
-    async fn age_filter_total_is_exact_when_exhausted_even_if_limit_hits_on_last_page() {
+    async fn age_filter_total_returns_native_total_when_exhausted() {
         let server = MockServer::start().await;
         let client = ClinicalTrialsClient::new_for_test(server.uri()).expect("client");
 
@@ -2714,19 +2733,19 @@ AREA[OfficialTitle](\"G12D\") OR AREA[BriefSummary](\"G12D\") OR AREA[Keyword](\
                 .await
                 .expect("page")
                 .total,
-            Some(12)
+            Some(20)
         );
         assert_eq!(
             search_page_with_ctgov_client(&client, &filters, 50, 0, None)
                 .await
                 .expect("page")
                 .total,
-            Some(12)
+            Some(20)
         );
     }
 
     #[tokio::test]
-    async fn count_all_traverses_all_ctgov_pages_for_age_filter() {
+    async fn count_all_uses_native_total_for_age_only_filters() {
         let server = MockServer::start().await;
         let client = ClinicalTrialsClient::new_for_test(server.uri()).expect("client");
 
@@ -2735,42 +2754,10 @@ AREA[OfficialTitle](\"G12D\") OR AREA[BriefSummary](\"G12D\") OR AREA[Keyword](\
             .and(query_param("query.cond", "melanoma"))
             .and(query_param("filter.overallStatus", "RECRUITING"))
             .and(query_param("countTotal", "true"))
-            .and(query_param("pageSize", "1000"))
+            .and(query_param("pageSize", "1"))
             .and(query_param_is_missing("pageToken"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-                "studies": studies_with_age_matches(100, 30, "51"),
-                "nextPageToken": "p2",
-                "totalCount": 250
-            })))
-            .expect(1)
-            .mount(&server)
-            .await;
-
-        Mock::given(method("GET"))
-            .and(path("/studies"))
-            .and(query_param("query.cond", "melanoma"))
-            .and(query_param("filter.overallStatus", "RECRUITING"))
-            .and(query_param("countTotal", "true"))
-            .and(query_param("pageSize", "1000"))
-            .and(query_param("pageToken", "p2"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-                "studies": studies_with_age_matches(100, 40, "52"),
-                "nextPageToken": "p3",
-                "totalCount": 250
-            })))
-            .expect(1)
-            .mount(&server)
-            .await;
-
-        Mock::given(method("GET"))
-            .and(path("/studies"))
-            .and(query_param("query.cond", "melanoma"))
-            .and(query_param("filter.overallStatus", "RECRUITING"))
-            .and(query_param("countTotal", "true"))
-            .and(query_param("pageSize", "1000"))
-            .and(query_param("pageToken", "p3"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-                "studies": studies_with_age_matches(50, 20, "53"),
+                "studies": [],
                 "nextPageToken": null,
                 "totalCount": 250
             })))
@@ -2783,7 +2770,7 @@ AREA[OfficialTitle](\"G12D\") OR AREA[BriefSummary](\"G12D\") OR AREA[Keyword](\
             count_all_with_ctgov_client(&client, &filters)
                 .await
                 .expect("count"),
-            90
+            Some(250)
         );
     }
 
@@ -2818,7 +2805,51 @@ AREA[OfficialTitle](\"G12D\") OR AREA[BriefSummary](\"G12D\") OR AREA[Keyword](\
             count_all_with_ctgov_client(&client, &filters)
                 .await
                 .expect("count"),
-            494
+            Some(494)
+        );
+    }
+
+    #[tokio::test]
+    async fn count_all_returns_unknown_when_expensive_post_filter_hits_page_cap() {
+        let server = MockServer::start().await;
+        let client = ClinicalTrialsClient::new_for_test(server.uri()).expect("client");
+
+        Mock::given(method("GET"))
+            .and(path("/studies"))
+            .and(query_param("query.cond", "melanoma"))
+            .and(query_param("countTotal", "true"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "studies": [ctgov_search_study_fixture("NCT99999999", "18 Years", "75 Years")],
+                "nextPageToken": "still-more",
+                "totalCount": 60000
+            })))
+            .expect(50)
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/studies/NCT99999999"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                ctgov_eligibility_detail_fixture(
+                    "NCT99999999",
+                    "Inclusion Criteria:\nMust have mismatch repair deficient disease",
+                ),
+            ))
+            .expect(50)
+            .mount(&server)
+            .await;
+
+        let filters = TrialSearchFilters {
+            condition: Some("melanoma".into()),
+            criteria: Some("mismatch repair deficient".into()),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            count_all_with_ctgov_client(&client, &filters)
+                .await
+                .expect("count"),
+            None
         );
     }
 }


### PR DESCRIPTION
## Summary

- **Age-only filters now use the fast path**: `MinimumAge`/`MaximumAge` are already present in the CTGov search response, so age-only `--count-only` queries return the native CTGov total in a single API call instead of traversing all pages with per-study detail fetches.
- **Bounded expensive post-filter traversal**: The `count_all` slow path (facility-geo and eligibility-keyword filters) now stops at 50 pages (`COUNT_TRAVERSAL_PAGE_CAP`). When the cap is hit, the CLI outputs `Total: unknown (traversal limit reached)` (text) or `{"total": null}` (JSON) instead of returning a misleading lower bound.
- **Renamed `uses_post_filters` → `uses_expensive_post_filters`** to accurately reflect that only facility-geo and eligibility-keyword verification requires expensive per-study detail fetches.

## Why

Previously, the `uses_post_filters` boolean collapsed cheap age filtering (in-memory comparison against search response fields) with expensive filters (N extra per-study detail fetches per page). This caused age-only count queries to traverse all result pages unnecessarily. Additionally, broad queries with expensive post-filters (e.g. a condition with 455k+ results) could run hundreds of sequential API fetches with no bound.

## Test plan

- [ ] `cargo test count_all` — 3 new unit tests cover cheap age path, native total semantics, and traversal-cap contract
- [ ] `cargo test age_filter` — updated age filter tests verify native-total semantics
- [ ] `cargo test` — 609 tests pass
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [ ] `make spec` — 103 spec tests pass including updated `spec/04-trial.md` age fast path section