### PR TITLE
Split volatile live-network specs out of PR CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,9 @@ jobs:
       - run: uv run pytest tests/ -v --mcp-cmd "biomcp serve"
       - run: uv run mkdocs build --strict
 
-  spec:
+  # Stable PR-blocking executable spec gate. Volatile live-network headings
+  # are excluded here and covered by spec-smoke.yml.
+  spec-stable:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -98,4 +100,4 @@ jobs:
       # Build the release binary first so make spec exercises target/release/biomcp,
       # not a stale editable install from .venv/bin.
       - run: cargo build --release --locked
-      - run: make spec
+      - run: make spec-pr

--- a/.github/workflows/spec-smoke.yml
+++ b/.github/workflows/spec-smoke.yml
@@ -1,0 +1,37 @@
+name: Spec smoke (volatile live-network)
+
+on:
+  schedule:
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+
+jobs:
+  # Full volatile live-network smoke lane. Classify headings in Makefile's
+  # SPEC_PR_DESELECT_ARGS comment block and keep PR-only exclusions there.
+  spec-volatile-live:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache protoc
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.tool_cache }}/protoc
+          key: protoc-${{ runner.os }}-${{ runner.arch }}-v28.3
+
+      - uses: arduino/setup-protoc@v3
+        continue-on-error: true
+        with:
+          version: "28.3"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - uses: astral-sh/setup-uv@v4
+
+      - run: cargo build --release --locked
+      - run: make spec

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,22 @@
-.PHONY: build test check run clean spec validate-skills test-contracts
+.PHONY: build test check run clean spec spec-pr validate-skills test-contracts
+
+# Volatile live-network spec headings. These headings fan out across article
+# search backends or have repeated timeout history in GitHub Actions, so they
+# run in the smoke workflow rather than the PR-blocking spec gate.
+#
+# PR gate: repo-local checks plus live-backed headings that have been stable
+# within the current CI timeout budget.
+# Smoke lane: `search article`, `gene articles`, `variant articles`,
+# `disease articles`, or any new heading with repeated provider-latency timeouts.
+# To move a heading into the smoke lane, add its exact pytest markdown node ID
+# below (file path + heading text after `::`).
+SPEC_PR_DESELECT_ARGS = \
+	--deselect "spec/02-gene.md::Gene to Articles" \
+	--deselect "spec/03-variant.md::Variant to Articles" \
+	--deselect "spec/06-article.md::Searching by Gene" \
+	--deselect "spec/06-article.md::Searching by Keyword" \
+	--deselect "spec/06-article.md::Sort Behavior" \
+	--deselect "spec/07-disease.md::Disease to Articles"
 
 build:
 	cargo build --release
@@ -24,6 +42,10 @@ clean:
 spec:
 	XDG_CACHE_HOME="$(CURDIR)/.cache" PATH="$(CURDIR)/target/release:$(PATH)" \
 		uv run --extra dev sh -c 'PATH="$(CURDIR)/target/release:$$PATH" pytest spec/ --mustmatch-lang bash --mustmatch-timeout 60 -v'
+
+spec-pr:
+	XDG_CACHE_HOME="$(CURDIR)/.cache" PATH="$(CURDIR)/target/release:$(PATH)" \
+		uv run --extra dev sh -c 'PATH="$(CURDIR)/target/release:$$PATH" pytest spec/ --mustmatch-lang bash --mustmatch-timeout 60 -v $(SPEC_PR_DESELECT_ARGS)'
 
 validate-skills:
 	XDG_CACHE_HOME="$(CURDIR)/.cache" PATH="$(CURDIR)/target/release:$(PATH)" \

--- a/analysis/technical/overview.md
+++ b/analysis/technical/overview.md
@@ -86,8 +86,10 @@ share one limiter budget and one Streamable HTTP `/mcp` surface.
      `version-sync` (`bash scripts/check-version-sync.sh`),
      `climb-hygiene` (`bash scripts/check-no-climb-tracked.sh`), and
      `contracts` (`uv sync --extra dev`, `uv run pytest tests/ -v --mcp-cmd "biomcp serve"`,
-     `uv run mkdocs build --strict`), and `spec` (`cargo build --release --locked`,
-     then `make spec`).
+     `uv run mkdocs build --strict`), and `spec-stable` (`cargo build --release --locked`,
+     then `make spec-pr`).
+   - Volatile live-network headings run separately in `.github/workflows/spec-smoke.yml`,
+     which runs the full `make spec` suite on a schedule and by manual dispatch.
    - Release validation runs the Rust checks again, then
      `uv run pytest tests/ -v --mcp-cmd "biomcp serve"` and
      `uv run mkdocs build --strict`.
@@ -105,9 +107,11 @@ BioMCP has three verification layers:
 
 ### 1. GitHub Workflows
 
-CI (`.github/workflows/ci.yml`) runs five parallel jobs: `check` (`cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test`), `version-sync` (`bash scripts/check-version-sync.sh`), `climb-hygiene` (`bash scripts/check-no-climb-tracked.sh`), `contracts` (`uv sync --extra dev`, `uv run pytest tests/ -v --mcp-cmd "biomcp serve"`, `uv run mkdocs build --strict`), and `spec` (`cargo build --release --locked`, then `make spec`).
+CI (`.github/workflows/ci.yml`) runs five parallel jobs: `check` (`cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test`), `version-sync` (`bash scripts/check-version-sync.sh`), `climb-hygiene` (`bash scripts/check-no-climb-tracked.sh`), `contracts` (`uv sync --extra dev`, `uv run pytest tests/ -v --mcp-cmd "biomcp serve"`, `uv run mkdocs build --strict`), and `spec-stable` (`cargo build --release --locked`, then `make spec-pr`).
 Contract smoke checks run in `.github/workflows/contracts.yml` on a schedule
 and by manual dispatch via `bash scripts/contract-smoke.sh`.
+Volatile live-network headings run separately in `.github/workflows/spec-smoke.yml`
+via the full `make spec` suite.
 release validation runs `pytest tests/` and `mkdocs build --strict` after the
 Rust checks before packaging and publishing artifacts.
 
@@ -118,10 +122,11 @@ exercises CLI output at the command level using stable structural markers
 (headers, table columns, query echoes) rather than brittle upstream data
 values.
 
-PR CI now runs `make spec` via the `spec` job in `.github/workflows/ci.yml`.
+PR CI now runs `make spec-pr` via the `spec-stable` job in `.github/workflows/ci.yml`.
 That job builds the release binary first, then relies on the Makefile's
 `target/release`-first `PATH` handling so specs do not accidentally execute a
-stale `.venv/bin/biomcp`.
+stale `.venv/bin/biomcp`. Volatile live-network headings run in the separate
+`Spec smoke (volatile live-network)` workflow instead.
 
 Run locally with `make spec`.
 

--- a/tests/test_upstream_planning_analysis_docs.py
+++ b/tests/test_upstream_planning_analysis_docs.py
@@ -132,8 +132,9 @@ def test_technical_and_ux_docs_match_current_cli_and_workflow_contracts() -> Non
     assert "`version-sync` (`bash scripts/check-version-sync.sh`)" in technical
     assert "`climb-hygiene` (`bash scripts/check-no-climb-tracked.sh`)" in technical
     assert '`contracts` (`uv sync --extra dev`, `uv run pytest tests/ -v --mcp-cmd "biomcp serve"`, `uv run mkdocs build --strict`)' in technical
-    assert "`spec` (`cargo build --release --locked`, then `make spec`)" in technical
-    assert "PR CI now runs `make spec` via the `spec` job in `.github/workflows/ci.yml`." in technical
+    assert "`spec-stable` (`cargo build --release --locked`, then `make spec-pr`)" in technical
+    assert "PR CI now runs `make spec-pr` via the `spec-stable` job in `.github/workflows/ci.yml`." in technical
+    assert "Volatile live-network headings run separately in `.github/workflows/spec-smoke.yml`" in technical
     assert "Contract smoke checks run in `.github/workflows/contracts.yml`" in technical
     assert "release validation runs `pytest tests/` and `mkdocs build --strict`" in technical
     assert "Streamable HTTP" in technical
@@ -164,6 +165,7 @@ def test_pull_request_contract_gate_matches_release_validation() -> None:
     ci = _read_repo(".github/workflows/ci.yml")
     release = _read_repo(".github/workflows/release.yml")
     contracts_smoke = _read_repo(".github/workflows/contracts.yml")
+    spec_smoke = _read_repo(".github/workflows/spec-smoke.yml")
     expected_contract_runs = [
         "uv sync --extra dev",
         'uv run pytest tests/ -v --mcp-cmd "biomcp serve"',
@@ -171,14 +173,16 @@ def test_pull_request_contract_gate_matches_release_validation() -> None:
     ]
 
     ci_contracts = _workflow_job_block(ci, "contracts")
-    ci_spec = _workflow_job_block(ci, "spec")
+    ci_spec = _workflow_job_block(ci, "spec-stable")
     ci_version_sync = _workflow_job_block(ci, "version-sync")
     ci_climb_hygiene = _workflow_job_block(ci, "climb-hygiene")
     release_validate = _workflow_job_block(release, "validate")
+    smoke_spec = _workflow_job_block(spec_smoke, "spec-volatile-live")
 
     assert 'python-version: "3.12"' in ci_contracts
     assert 'python-version: "3.12"' in ci_spec
     assert 'python-version: "3.12"' in release_validate
+    assert 'python-version: "3.12"' in smoke_spec
     assert _workflow_run_steps(ci_contracts) == expected_contract_runs
     assert "- uses: actions/checkout@v4" in ci_spec
     assert "uses: arduino/setup-protoc@v3" in ci_spec
@@ -187,7 +191,7 @@ def test_pull_request_contract_gate_matches_release_validation() -> None:
     assert "uses: astral-sh/setup-uv@v4" in ci_spec
     assert _workflow_run_steps(ci_spec) == [
         "cargo build --release --locked",
-        "make spec",
+        "make spec-pr",
     ]
     assert _workflow_run_steps(release_validate)[-3:] == expected_contract_runs
     assert "- uses: actions/checkout@v4" in ci_version_sync
@@ -224,6 +228,44 @@ def test_pull_request_contract_gate_matches_release_validation() -> None:
     assert "workflow_dispatch:" in contracts_smoke
     assert "continue-on-error: true" in contracts_smoke
     assert "- run: bash scripts/contract-smoke.sh" in contracts_smoke
+
+    assert "name: Spec smoke (volatile live-network)" in spec_smoke
+    assert 'cron: "0 7 * * *"' in spec_smoke
+    assert "workflow_dispatch:" in spec_smoke
+    assert "- uses: actions/checkout@v4" in smoke_spec
+    assert "uses: arduino/setup-protoc@v3" in smoke_spec
+    assert "uses: dtolnay/rust-toolchain@stable" in smoke_spec
+    assert "uses: actions/setup-python@v5" in smoke_spec
+    assert "uses: astral-sh/setup-uv@v4" in smoke_spec
+    assert _workflow_run_steps(smoke_spec) == [
+        "cargo build --release --locked",
+        "make spec",
+    ]
+
+
+def test_makefile_spec_split_contract_is_documented_and_executable() -> None:
+    makefile = _read_repo("Makefile")
+
+    assert ".PHONY: build test check run clean spec spec-pr validate-skills test-contracts" in makefile
+    assert "Volatile live-network spec headings." in makefile
+    assert "PR gate: repo-local checks plus live-backed headings that have been stable" in makefile
+    assert "Smoke lane: `search article`, `gene articles`, `variant articles`," in makefile
+    assert "To move a heading into the smoke lane, add its exact pytest markdown node ID" in makefile
+    assert 'SPEC_PR_DESELECT_ARGS = \\' in makefile
+    for node_id in (
+        'spec/02-gene.md::Gene to Articles',
+        'spec/03-variant.md::Variant to Articles',
+        'spec/06-article.md::Searching by Gene',
+        'spec/06-article.md::Searching by Keyword',
+        'spec/06-article.md::Sort Behavior',
+        'spec/07-disease.md::Disease to Articles',
+    ):
+        assert f'--deselect "{node_id}"' in makefile
+    assert re.search(
+        r"^spec-pr:\n\tXDG_CACHE_HOME=\"\$\(CURDIR\)/\.cache\" PATH=\"\$\(CURDIR\)/target/release:\$\(PATH\)\" \\\n\t\tuv run --extra dev sh -c 'PATH=\"\$\(CURDIR\)/target/release:\$\$PATH\" pytest spec/ --mustmatch-lang bash --mustmatch-timeout 60 -v \$\(SPEC_PR_DESELECT_ARGS\)'$",
+        makefile,
+        flags=re.MULTILINE,
+    )
 
 
 def test_runtime_contract_docs_and_scripts_align_on_release_target() -> None:


### PR DESCRIPTION
## Summary

- Renames the PR-blocking spec CI job from `spec` to `spec-stable` and switches it to run only the deterministic/high-signal spec subset via `make spec-pr`
- Adds `spec-smoke.yml` — a separate workflow that runs the full spec suite (`make spec`) on a daily schedule and via `workflow_dispatch`, covering the volatile live-network article/disease headings without blocking PRs
- Documents the PR-gate vs smoke-lane boundary in the Makefile (`SPEC_PR_DESELECT_ARGS` block) and in `analysis/technical/overview.md`

The six spec headings that were causing PR CI timeouts (article and disease retrieval against Europe PMC, PubTator, and MyDisease) are now excluded from the PR-blocking gate and covered by the dedicated smoke workflow instead.

## Test plan

- [ ] `CI / spec-stable` passes on this PR (97 passed, 5 skipped, 7 deselected)
- [ ] Contract tests (`tests/test_upstream_planning_analysis_docs.py`) green (9 passed)
- [ ] After merge, navigate to Actions tab and manually trigger `Spec smoke (volatile live-network)` to confirm the full-suite lane is visible and runnable