### PR TITLE
Build contracts CI against branch biomcp binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,8 +66,9 @@ jobs:
 
       - uses: astral-sh/setup-uv@v4
 
+      - run: cargo build --release --locked
       - run: uv sync --extra dev
-      - run: uv run pytest tests/ -v --mcp-cmd "biomcp serve"
+      - run: uv run pytest tests/ -v --mcp-cmd "./target/release/biomcp serve"
       - run: uv run mkdocs build --strict
 
   # Stable PR-blocking executable spec gate. Volatile live-network headings

--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,9 @@ test:
 	cargo test
 
 test-contracts:
+	cargo build --release --locked
 	uv sync --extra dev
-	uv run pytest tests/ -v --mcp-cmd "biomcp serve"
+	uv run pytest tests/ -v --mcp-cmd "./target/release/biomcp serve"
 	uv run mkdocs build --strict
 
 check:

--- a/RUN.md
+++ b/RUN.md
@@ -93,10 +93,7 @@ Run the Python/docs contract gate (same as PR CI `contracts` job):
 make test-contracts
 ```
 
-`make test-contracts` runs `uv sync --extra dev`, `pytest tests/`, and
-`mkdocs build --strict` - the same steps that PR CI and release validation
-require. Use this to catch docs-contract and Python regressions before
-pushing.
+`make test-contracts` runs `cargo build --release --locked`, `uv sync --extra dev`, `pytest tests/ -v --mcp-cmd "./target/release/biomcp serve"`, and `mkdocs build --strict` - the same steps that PR CI `contracts` requires. Use this to catch docs-contract and Python regressions before pushing.
 
 ## Smoke Checks
 

--- a/analysis/technical/overview.md
+++ b/analysis/technical/overview.md
@@ -85,9 +85,10 @@ share one limiter budget and one Streamable HTTP `/mcp` surface.
      (`cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test`),
      `version-sync` (`bash scripts/check-version-sync.sh`),
      `climb-hygiene` (`bash scripts/check-no-climb-tracked.sh`), and
-     `contracts` (`uv sync --extra dev`, `uv run pytest tests/ -v --mcp-cmd "biomcp serve"`,
-     `uv run mkdocs build --strict`), and `spec-stable` (`cargo build --release --locked`,
-     then `make spec-pr`).
+     `contracts` (`cargo build --release --locked`, `uv sync --extra dev`,
+     `uv run pytest tests/ -v --mcp-cmd "./target/release/biomcp serve"`,
+     `uv run mkdocs build --strict`), and `spec-stable`
+     (`cargo build --release --locked`, then `make spec-pr`).
    - Volatile live-network headings run separately in `.github/workflows/spec-smoke.yml`,
      which runs the full `make spec` suite on a schedule and by manual dispatch.
    - Release validation runs the Rust checks again, then
@@ -107,7 +108,7 @@ BioMCP has three verification layers:
 
 ### 1. GitHub Workflows
 
-CI (`.github/workflows/ci.yml`) runs five parallel jobs: `check` (`cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test`), `version-sync` (`bash scripts/check-version-sync.sh`), `climb-hygiene` (`bash scripts/check-no-climb-tracked.sh`), `contracts` (`uv sync --extra dev`, `uv run pytest tests/ -v --mcp-cmd "biomcp serve"`, `uv run mkdocs build --strict`), and `spec-stable` (`cargo build --release --locked`, then `make spec-pr`).
+CI (`.github/workflows/ci.yml`) runs five parallel jobs: `check` (`cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test`), `version-sync` (`bash scripts/check-version-sync.sh`), `climb-hygiene` (`bash scripts/check-no-climb-tracked.sh`), `contracts` (`cargo build --release --locked`, `uv sync --extra dev`, `uv run pytest tests/ -v --mcp-cmd "./target/release/biomcp serve"`, `uv run mkdocs build --strict`), and `spec-stable` (`cargo build --release --locked`, then `make spec-pr`).
 Contract smoke checks run in `.github/workflows/contracts.yml` on a schedule
 and by manual dispatch via `bash scripts/contract-smoke.sh`.
 Volatile live-network headings run separately in `.github/workflows/spec-smoke.yml`

--- a/tests/test_upstream_planning_analysis_docs.py
+++ b/tests/test_upstream_planning_analysis_docs.py
@@ -131,7 +131,12 @@ def test_technical_and_ux_docs_match_current_cli_and_workflow_contracts() -> Non
     assert "`check` (`cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test`)" in technical
     assert "`version-sync` (`bash scripts/check-version-sync.sh`)" in technical
     assert "`climb-hygiene` (`bash scripts/check-no-climb-tracked.sh`)" in technical
-    assert '`contracts` (`uv sync --extra dev`, `uv run pytest tests/ -v --mcp-cmd "biomcp serve"`, `uv run mkdocs build --strict`)' in technical
+    assert (
+        '`contracts` (`cargo build --release --locked`, `uv sync --extra dev`, '
+        '`uv run pytest tests/ -v --mcp-cmd "./target/release/biomcp serve"`, '
+        '`uv run mkdocs build --strict`)'
+        in technical
+    )
     assert "`spec-stable` (`cargo build --release --locked`, then `make spec-pr`)" in technical
     assert "PR CI now runs `make spec-pr` via the `spec-stable` job in `.github/workflows/ci.yml`." in technical
     assert "Volatile live-network headings run separately in `.github/workflows/spec-smoke.yml`" in technical
@@ -166,7 +171,13 @@ def test_pull_request_contract_gate_matches_release_validation() -> None:
     release = _read_repo(".github/workflows/release.yml")
     contracts_smoke = _read_repo(".github/workflows/contracts.yml")
     spec_smoke = _read_repo(".github/workflows/spec-smoke.yml")
-    expected_contract_runs = [
+    expected_ci_contract_runs = [
+        "cargo build --release --locked",
+        "uv sync --extra dev",
+        'uv run pytest tests/ -v --mcp-cmd "./target/release/biomcp serve"',
+        "uv run mkdocs build --strict",
+    ]
+    expected_release_contract_runs = [
         "uv sync --extra dev",
         'uv run pytest tests/ -v --mcp-cmd "biomcp serve"',
         "uv run mkdocs build --strict",
@@ -183,7 +194,7 @@ def test_pull_request_contract_gate_matches_release_validation() -> None:
     assert 'python-version: "3.12"' in ci_spec
     assert 'python-version: "3.12"' in release_validate
     assert 'python-version: "3.12"' in smoke_spec
-    assert _workflow_run_steps(ci_contracts) == expected_contract_runs
+    assert _workflow_run_steps(ci_contracts) == expected_ci_contract_runs
     assert "- uses: actions/checkout@v4" in ci_spec
     assert "uses: arduino/setup-protoc@v3" in ci_spec
     assert "uses: dtolnay/rust-toolchain@stable" in ci_spec
@@ -193,7 +204,7 @@ def test_pull_request_contract_gate_matches_release_validation() -> None:
         "cargo build --release --locked",
         "make spec-pr",
     ]
-    assert _workflow_run_steps(release_validate)[-3:] == expected_contract_runs
+    assert _workflow_run_steps(release_validate)[-3:] == expected_release_contract_runs
     assert "- uses: actions/checkout@v4" in ci_version_sync
     assert _workflow_run_steps(ci_version_sync) == [
         "bash scripts/check-version-sync.sh"
@@ -266,6 +277,15 @@ def test_makefile_spec_split_contract_is_documented_and_executable() -> None:
         makefile,
         flags=re.MULTILINE,
     )
+    assert re.search(
+        r"^test-contracts:\n"
+        r"\tcargo build --release --locked\n"
+        r"\tuv sync --extra dev\n"
+        r'\tuv run pytest tests/ -v --mcp-cmd "\./target/release/biomcp serve"\n'
+        r"\tuv run mkdocs build --strict$",
+        makefile,
+        flags=re.MULTILINE,
+    )
 
 
 def test_runtime_contract_docs_and_scripts_align_on_release_target() -> None:
@@ -305,6 +325,12 @@ def test_runtime_contract_docs_and_scripts_align_on_release_target() -> None:
     assert "tests/test_mcp_http_transport.py" in runbook
     assert "make spec" in runbook
     assert "make test-contracts" in runbook
+    assert (
+        '`make test-contracts` runs `cargo build --release --locked`, '
+        '`uv sync --extra dev`, `pytest tests/ -v --mcp-cmd "./target/release/biomcp serve"`, '
+        'and `mkdocs build --strict` - the same steps that PR CI `contracts` requires.'
+        in runbook
+    )
     assert "docs/user-guide/cli-reference.md" in runbook
     assert "docs/reference/mcp-server.md" in runbook
 


### PR DESCRIPTION
## Summary

- Add `cargo build --release --locked` as the first step in the `contracts` CI job so the job validates the branch binary rather than the last published PyPI wheel
- Update pytest invocation to use `--mcp-cmd "./target/release/biomcp serve"` instead of relying on the wheel-installed `biomcp` command
- Mirror the same four-step sequence in `make test-contracts` so local and CI contract proofs stay in sync
- Update `analysis/technical/overview.md` and `RUN.md` to document the current local contract proof
- Extend `tests/test_upstream_planning_analysis_docs.py` to split CI vs release contract expectations, preventing silent regression back to wheel-only validation

## Why

The `contracts` CI lane was exercising the last published PyPI wheel instead of the branch under review. PRs could pass CI even when CLI or MCP contract changes would have failed once the new binary was shipped. This change closes that verification gap so the `contracts` gate reflects actual repo-head behavior.

## Test plan

- [ ] `make test-contracts` passes (cargo build → pytest 53/53 → mkdocs build)
- [ ] `uv run pytest tests/test_upstream_planning_analysis_docs.py -v` passes (9/9)
- [ ] CI `contracts` job passes on this PR (validates the new build step runs first)
- [ ] `release.yml` validate job is unchanged (wheel-based path intentionally preserved)