### PR TITLE
Signal approximate totals for age-only trial count searches

### DIFF
--- a/spec/04-trial.md
+++ b/spec/04-trial.md
@@ -39,12 +39,28 @@ of display limit. This guards the regression where age was incorrectly grouped
 with expensive detail-verified post-filters and `Total:` changed with `--limit`.
 
 ```bash
-t10="$("$(git rev-parse --show-toplevel)/target/release/biomcp" search trial -c melanoma -s recruiting --age 51 --limit 10 --count-only | sed -n 's/^Total: //p')"
-t20="$("$(git rev-parse --show-toplevel)/target/release/biomcp" search trial -c melanoma -s recruiting --age 51 --limit 20 --count-only | sed -n 's/^Total: //p')"
-t50="$("$(git rev-parse --show-toplevel)/target/release/biomcp" search trial -c melanoma -s recruiting --age 51 --limit 50 --count-only | sed -n 's/^Total: //p')"
+t10="$("$(git rev-parse --show-toplevel)/target/release/biomcp" search trial -c melanoma -s recruiting --age 51 --limit 10 --count-only | sed -n 's/^Total: \([0-9]*\).*/\1/p')"
+t20="$("$(git rev-parse --show-toplevel)/target/release/biomcp" search trial -c melanoma -s recruiting --age 51 --limit 20 --count-only | sed -n 's/^Total: \([0-9]*\).*/\1/p')"
+t50="$("$(git rev-parse --show-toplevel)/target/release/biomcp" search trial -c melanoma -s recruiting --age 51 --limit 50 --count-only | sed -n 's/^Total: \([0-9]*\).*/\1/p')"
 test -n "$t10"
 test "$t10" = "$t20"
 test "$t20" = "$t50"
+```
+
+## Age-Only Count Approximation Signal
+
+When age is the only non-API filter, `--count-only` must signal that the total
+comes from the upstream CTGov fast-count path and is only approximate after
+BioMCP's client-side age post-filter.
+
+```bash timeout=180
+out="$("$(git rev-parse --show-toplevel)/target/release/biomcp" search trial -c melanoma -s recruiting --age 51 --count-only)"
+echo "$out" | mustmatch like "Total: "
+echo "$out" | mustmatch like "(approximate, age post-filtered)"
+
+json_out="$("$(git rev-parse --show-toplevel)/target/release/biomcp" search trial -c melanoma -s recruiting --age 51 --count-only --json)"
+echo "$json_out" | mustmatch like "\"total\":"
+echo "$json_out" | mustmatch like "\"approximate\": true"
 ```
 
 ## Expensive Count Traversal Cap
@@ -157,4 +173,5 @@ echo "$out" | mustmatch like "materially more expensive"
 echo "$out" | mustmatch like "combined Phase 1/Phase 2 label"
 echo "$out" | mustmatch like "not Phase 1 OR Phase 2"
 echo "$out" | mustmatch like "no sex restriction"
+echo "$out" | tr '\n' ' ' | mustmatch like "age-only CTGov searches report an approximate upstream total"
 ```

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -579,7 +579,11 @@ See also: biomcp list trial")]
         #[arg(long = "study-type")]
         study_type: Option<String>,
 
-        /// Patient age in years for eligibility matching (decimals accepted, e.g. 0.5 for 6 months)
+        /// Patient age in years for eligibility matching (decimals accepted, e.g. 0.5 for 6 months).
+        ///
+        /// With `--count-only`, age-only CTGov searches report an approximate
+        /// upstream total because BioMCP applies the age filter during full
+        /// search, not the fast count path.
         #[arg(long)]
         age: Option<f32>,
 
@@ -4497,19 +4501,36 @@ pub async fn run(cli: Cli) -> anyhow::Result<String> {
                     let query =
                         trial_search_query_summary(&filters, offset, next_page.as_deref());
                     if count_only {
-                        let total = crate::entities::trial::count_all(&filters).await?;
+                        let count = crate::entities::trial::count_all(&filters).await?;
                         if cli.json {
+                            use crate::entities::trial::TrialCount;
+
                             #[derive(serde::Serialize)]
                             struct TrialCountOnlyJson {
                                 total: Option<usize>,
+                                #[serde(skip_serializing_if = "Option::is_none")]
+                                approximate: Option<bool>,
                             }
+                            let (total, approximate) = match count {
+                                TrialCount::Exact(total) => (Some(total), None),
+                                TrialCount::Approximate(total) => (Some(total), Some(true)),
+                                TrialCount::Unknown => (None, None),
+                            };
                             return Ok(crate::render::json::to_pretty(&TrialCountOnlyJson {
                                 total,
+                                approximate,
                             })?);
                         }
-                        return Ok(match total {
-                            Some(total) => format!("Total: {total}"),
-                            None => "Total: unknown (traversal limit reached)".to_string(),
+                        return Ok(match count {
+                            crate::entities::trial::TrialCount::Exact(total) => {
+                                format!("Total: {total}")
+                            }
+                            crate::entities::trial::TrialCount::Approximate(total) => {
+                                format!("Total: {total} (approximate, age post-filtered)")
+                            }
+                            crate::entities::trial::TrialCount::Unknown => {
+                                "Total: unknown (traversal limit reached)".to_string()
+                            }
                         });
                     }
                     let page = crate::entities::trial::search_page(
@@ -5284,6 +5305,13 @@ mod tests {
 
         assert!(help.contains("all"));
         assert!(help.contains("no sex restriction"));
+    }
+
+    #[test]
+    fn trial_age_help_explains_age_only_count_is_approximate() {
+        let help = render_trial_search_long_help();
+
+        assert!(help.contains("age-only CTGov searches report an approximate upstream total"));
     }
 
     #[test]

--- a/src/entities/trial.rs
+++ b/src/entities/trial.rs
@@ -184,6 +184,18 @@ const FACILITY_GEO_VERIFY_CONCURRENCY: usize = 8;
 const ELIGIBILITY_VERIFY_CONCURRENCY: usize = 8;
 const CTGOV_MAX_PAGE_FETCHES: usize = 20;
 const CTGOV_COUNT_PAGE_SIZE: usize = 1000;
+const COUNT_TRAVERSAL_PAGE_CAP: usize = 50;
+
+/// Describes the precision of a trial `--count-only` result.
+#[derive(Debug, PartialEq)]
+pub enum TrialCount {
+    /// Exact post-filtered count.
+    Exact(usize),
+    /// Upstream CTGov total before client-side age post-filtering.
+    Approximate(usize),
+    /// Traversal cap was hit, so the exact total is unknown.
+    Unknown,
+}
 
 #[derive(Debug, Clone, Copy, Default)]
 struct TrialSections {
@@ -1680,9 +1692,7 @@ async fn search_page_with_ctgov_client(
 async fn count_all_with_ctgov_client(
     client: &ClinicalTrialsClient,
     filters: &TrialSearchFilters,
-) -> Result<Option<usize>, BioMcpError> {
-    const COUNT_TRAVERSAL_PAGE_CAP: usize = 50;
-
+) -> Result<TrialCount, BioMcpError> {
     if !matches!(filters.source, TrialSource::ClinicalTrialsGov) {
         return Err(BioMcpError::InvalidArgument(
             "internal ctgov count helper requires --source ctgov".into(),
@@ -1696,7 +1706,12 @@ async fn count_all_with_ctgov_client(
         let resp = client
             .search(&build_ctgov_search_params(filters, &context, None, 1))
             .await?;
-        return Ok(Some(resp.total_count.unwrap_or(0) as usize));
+        let total = resp.total_count.unwrap_or(0) as usize;
+        return Ok(if filters.age.is_some() {
+            TrialCount::Approximate(total)
+        } else {
+            TrialCount::Exact(total)
+        });
     }
 
     let mut verified_total = 0usize;
@@ -1705,7 +1720,7 @@ async fn count_all_with_ctgov_client(
 
     loop {
         if page_count >= COUNT_TRAVERSAL_PAGE_CAP {
-            return Ok(None);
+            return Ok(TrialCount::Unknown);
         }
 
         let resp = client
@@ -1728,10 +1743,10 @@ async fn count_all_with_ctgov_client(
         page_token = next_page_token;
     }
 
-    Ok(Some(verified_total))
+    Ok(TrialCount::Exact(verified_total))
 }
 
-pub async fn count_all(filters: &TrialSearchFilters) -> Result<Option<usize>, BioMcpError> {
+pub async fn count_all(filters: &TrialSearchFilters) -> Result<TrialCount, BioMcpError> {
     match filters.source {
         TrialSource::ClinicalTrialsGov => {
             let client = ClinicalTrialsClient::new()?;
@@ -1739,7 +1754,7 @@ pub async fn count_all(filters: &TrialSearchFilters) -> Result<Option<usize>, Bi
         }
         TrialSource::NciCts => {
             let page = search_page(filters, 1, 0, None).await?;
-            Ok(Some(page.total.unwrap_or(page.results.len())))
+            Ok(TrialCount::Exact(page.total.unwrap_or(page.results.len())))
         }
     }
 }
@@ -2899,7 +2914,7 @@ AREA[OfficialTitle](\"G12D\") OR AREA[BriefSummary](\"G12D\") OR AREA[Keyword](\
     }
 
     #[tokio::test]
-    async fn count_all_uses_native_total_for_age_only_filters() {
+    async fn count_all_returns_approximate_for_age_only_filters() {
         let server = MockServer::start().await;
         let client = ClinicalTrialsClient::new_for_test(server.uri()).expect("client");
 
@@ -2924,12 +2939,12 @@ AREA[OfficialTitle](\"G12D\") OR AREA[BriefSummary](\"G12D\") OR AREA[Keyword](\
             count_all_with_ctgov_client(&client, &filters)
                 .await
                 .expect("count"),
-            Some(250)
+            TrialCount::Approximate(250)
         );
     }
 
     #[tokio::test]
-    async fn count_all_uses_native_total_without_post_filters() {
+    async fn count_all_returns_exact_for_no_post_filters() {
         let server = MockServer::start().await;
         let client = ClinicalTrialsClient::new_for_test(server.uri()).expect("client");
 
@@ -2959,7 +2974,7 @@ AREA[OfficialTitle](\"G12D\") OR AREA[BriefSummary](\"G12D\") OR AREA[Keyword](\
             count_all_with_ctgov_client(&client, &filters)
                 .await
                 .expect("count"),
-            Some(494)
+            TrialCount::Exact(494)
         );
     }
 
@@ -3003,7 +3018,7 @@ AREA[OfficialTitle](\"G12D\") OR AREA[BriefSummary](\"G12D\") OR AREA[Keyword](\
             count_all_with_ctgov_client(&client, &filters)
                 .await
                 .expect("count"),
-            None
+            TrialCount::Unknown
         );
     }
 }


### PR DESCRIPTION
## Summary

- Age-only `--count-only` trial searches now signal that the returned total is approximate, since BioMCP's age post-filter runs during full search rather than the fast count path
- Text output appends `(approximate, age post-filtered)` to the total; JSON output adds `"approximate": true`
- The `--age` help text notes the approximation behavior for CTGov-only fast-count paths
- `COUNT_TRAVERSAL_PAGE_CAP` is hoisted to the module-level constant block alongside other traversal constants

## Details

When a user runs `biomcp search trial --age N --count-only`, BioMCP previously returned CTGov's upstream total without indicating that the actual result set may be smaller after client-side age filtering. This change makes that approximation explicit.

A new `TrialCount` enum (`Exact`, `Approximate`, `Unknown`) annotates the return type of `count_all_with_ctgov_client` and `count_all`. The `Approximate` variant fires only on the CTGov age-only fast path. All other count paths continue returning `Exact` or `Unknown` as before, with no change to their output.

## Test plan

- [ ] `make build` passes
- [ ] `make test` passes (632 tests)
- [ ] `make check` passes (clippy + fmt)
- [ ] `make spec` passes (113 passed, 5 skipped)
- [ ] Age-only `--count-only` text output shows `(approximate, age post-filtered)` qualifier
- [ ] Age-only `--count-only` JSON output includes `"approximate": true`
- [ ] Non-age `--count-only` output is unchanged (no qualifier, no `approximate` field)