### PR TITLE
Upgrade quinn-proto and PyJWT to fix security vulnerabilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1900,9 +1900,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/uv.lock
+++ b/uv.lock
@@ -917,11 +917,14 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.11.0"
+version = "2.12.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5a/b46fa56bf322901eee5b0454a34343cdbdae202cd421775a8ee4e42fd519/pyjwt-2.11.0.tar.gz", hash = "sha256:35f95c1f0fbe5d5ba6e43f00271c275f7a1a4db1dab27bf708073b75318ea623", size = 98019, upload-time = "2026-01-30T19:59:55.694Z" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/01/c26ce75ba460d5cd503da9e13b21a33804d38c2165dec7b716d06b13010c/pyjwt-2.11.0-py3-none-any.whl", hash = "sha256:94a6bde30eb5c8e04fee991062b534071fd1439ef58d2adc9ccb823e7bcd0469", size = 28224, upload-time = "2026-01-30T19:59:54.539Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

- Bump `quinn-proto` from 0.11.13 to 0.11.14 in `Cargo.lock` to fix an unauthenticated remote DoS via panic in QUIC transport parameter parsing (GHSA-6xvm-j4wr-6v98 / CVE-2026-31812)
- Bump `PyJWT` from 2.11.0 to 2.12.1 in `uv.lock` to fix acceptance of unknown `crit` header extensions that could bypass JWT validation (GHSA-752w-5fwx-jx9f / CVE-2026-32597)

Both are transitive lockfile-only changes. `Cargo.toml` and `pyproject.toml` are unchanged.

## Test plan

- [x] `cargo test` passes (all Rust tests green)
- [x] `uv run pytest tests/ -v` passes (53 Python tests)
- [x] `make build`, `make check` pass
- [x] Dependabot alerts #44 and #45 expected to auto-close after merge