### PR TITLE
Bump h2 to 0.4.16 for RUSTSEC-2026-0258, and draft the MkDocs migration ticket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1185,9 +1185,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/sdlc/tickets/drafts/1021-move-the-documentation-build-off-unmaintained-mkdocs.md
+++ b/sdlc/tickets/drafts/1021-move-the-documentation-build-off-unmaintained-mkdocs.md
@@ -1,0 +1,40 @@
+---
+flow: build
+priority: 3
+hold: the replacement generator is not chosen yet; Ian picks before promotion
+---
+# Move the documentation build off unmaintained MkDocs
+
+The `make test` gate ends in `mkdocs build --strict`, and that build now prints a warning on every run: MkDocs 1.x is unmaintained, and MkDocs 2.0 is incompatible with Material for MkDocs. The Material authors are directing users to Zensical, their own replacement generator. Nothing is broken today — the build passes and the published site is correct — but the toolchain under it has no maintainer, so the next security advisory or Python version bump lands with no upstream fix available.
+
+Docs are the public face of BioMCP. `biomcp.org` is served from the `gh-pages` branch, and the site must keep serving the same pages at the same URLs throughout and after this change. A migration that renames or drops URLs breaks inbound links from the MCP registry, the README, and anything an agent has already learned.
+
+The current setup is small, which is what makes this tractable: one built-in plugin (`search`), the Material theme with a features list, a hand-written `nav`, and eleven Markdown extensions, all in `mkdocs.yml`. There are no custom plugins and no generated navigation.
+
+## The decision that comes first
+
+This ticket must not run until someone chooses the destination. The realistic options are to move to Zensical, to stay on MkDocs 1.x behind an explicit pin and accept it as unmaintained, or to move to a different generator entirely. Those lead to genuinely different work, and an agent cannot pick for us. When the choice is made, write it into this ticket as a single named destination and delete the `hold:` line.
+
+## Done when
+
+- The documentation build runs on a maintained toolchain, with no unmaintained-dependency warning in the output of `make test`.
+- Every page reachable in the published site before the change is reachable at the same URL after it.
+- The rendered output still carries the things the current theme provides and the docs rely on: working search, admonitions, tabbed content blocks, syntax-highlighted code with line anchors, snippet includes, and permalinked headings.
+- The strict build still fails on a broken internal link, the same way `--strict` does today.
+- The build still runs inside the offline sandbox with no public network access, exactly as `make test` invokes it now.
+- The publish path to `gh-pages` still works and is exercised at least once before this ticket is called done.
+
+## Existing tests that pin this
+
+These assert against the docs tree or the docs build and may need restating as part of the design stage. Restatement is authorized for these files by name:
+
+- `tests/test_docs_changelog_refresh.py`
+- `tests/test_source_pages_docs_contract.py`
+- `tests/test_source_licensing_docs_contract.py`
+- `tests/test_public_search_all_docs_contract.py`
+- `tests/test_cross_entity_pivots_docs_contract.py`
+- `tests/test_bioasq_benchmark_contract.py`
+- `tests/test_pre_commit_reject_march_artifacts.py`
+- `tests/surface/test_ticket_405_architecture_operator_contracts.py`
+
+The dependency pin lives at `pyproject.toml:35` (`mkdocs-material>=9.5`); the build command is `Makefile:41`.


### PR DESCRIPTION
Main is red on the advisory gate. `cargo deny check advisories` fails on h2 0.4.13 (RUSTSEC-2026-0258): it accepts and queues empty DATA frames without limit, which can reach unbounded memory or a length-overflow panic if streams are not drained. Low severity, patched upstream in 0.4.16. h2 comes in transitively through hyper and tonic, so no source change is needed.

## Why the lockfile was edited by hand

Running `cargo update -p h2` fixes the advisory but produces a 20-line diff, because the resolver also **downgrades** three unrelated things: `socket2` 0.6.2 to 0.5.10, and `windows-sys` 0.61.2 to 0.52.0 in four places (one to 0.48.0). Those are collateral, they pull in older code, and most of them are Windows-only — the part covered by `windows-contracts` and hardest to check locally.

So this patches the h2 entry alone: version and checksum, two lines. h2 0.4.16 declares the same dependency set as 0.4.13, and `cargo metadata --locked` accepts the result.

## Gates, run locally

| Gate | Result |
| --- | --- |
| `make lint` | pass, exit 0, `advisories ok` |
| `make test` | pass, 762 passed / 3 skipped |
| `make spec` | pass, 36 + 8 |

## Second commit

Adds `sdlc/tickets/drafts/1021-move-the-documentation-build-off-unmaintained-mkdocs.md`. The `make test` docs build now warns on every run that MkDocs 1.x is unmaintained and that MkDocs 2.0 is incompatible with Material for MkDocs. Held in `drafts/` with a `hold:` line, because the destination is a human decision — Zensical, an explicit pin on the unmaintained version, or a different generator entirely — and those lead to different work. Sync does not read `drafts/`, so it stays off the board until that is settled.