### PR TITLE
Emit the servers key VS Code actually reads from mcp-config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,14 @@
 
 ### Fixes
 
+- Emitted the `servers` key VS Code actually reads from `biomcp mcp-config
+  --client vscode`, instead of the `mcpServers` key the other stdio clients
+  use. VS Code parsed the old snippet without complaint and then ignored it,
+  so the server never appeared and nothing said why. Public MCP client docs
+  now show the same corrected shape.
+- Bumped the `h2` lockfile entry to 0.4.16 for RUSTSEC-2026-0258, which
+  accepted and queued empty DATA frames without limit. `h2` is a transitive
+  dependency of hyper and tonic, so no source change was needed.
 - Hardened CLI correctness before the next development candidate: local study
   discovery now treats a missing data directory as an empty catalog and drops
   invalid survival times; phenotype search has truthful 50-result paging and a

--- a/docs/getting-started/mcp-clients.md
+++ b/docs/getting-started/mcp-clients.md
@@ -151,11 +151,11 @@ Generate the VS Code config:
 biomcp mcp-config --client vscode
 ```
 
-Or add this server to your VS Code MCP configuration:
+Or add this server to `.vscode/mcp.json` in your workspace, or to the file VS Code opens with **MCP: Open User Configuration**. VS Code reads `servers` here, not the `mcpServers` key the other clients use — a snippet under the wrong key is valid JSON and is then silently ignored, so the server never shows up.
 
 ```json
 {
-  "mcpServers": {
+  "servers": {
     "biomcp": {
       "command": "biomcp",
       "args": ["serve"]

--- a/src/cli/mcp_config.rs
+++ b/src/cli/mcp_config.rs
@@ -12,6 +12,14 @@ struct McpServersConfig<'a> {
     mcp_servers: std::collections::BTreeMap<&'static str, McpServerConfig<'a>>,
 }
 
+/// VS Code reads `servers` in `mcp.json`, not the `mcpServers` key the other
+/// clients use. A snippet under the wrong key parses fine and is then ignored,
+/// so the server simply never appears.
+#[derive(Serialize)]
+struct VscodeServersConfig<'a> {
+    servers: std::collections::BTreeMap<&'static str, McpServerConfig<'a>>,
+}
+
 #[derive(Serialize)]
 struct McpServerConfig<'a> {
     command: &'a str,
@@ -39,24 +47,39 @@ fn render(client: Option<McpClient>, command: &str) -> anyhow::Result<String> {
         Some(McpClient::ClaudeCode) => json_config(command)?,
         Some(McpClient::Cursor) => json_config(command)?,
         Some(McpClient::Cline) => json_config(command)?,
-        Some(McpClient::Vscode) => json_config(command)?,
+        Some(McpClient::Vscode) => vscode_config(command)?,
         Some(McpClient::Json) => json_config(command)?,
         None => discovery_page(),
     })
 }
 
-fn json_config(command: &str) -> anyhow::Result<String> {
-    let mut mcp_servers = std::collections::BTreeMap::new();
-    mcp_servers.insert(
+fn server_entry(command: &str) -> std::collections::BTreeMap<&'static str, McpServerConfig<'_>> {
+    let mut servers = std::collections::BTreeMap::new();
+    servers.insert(
         SERVER_NAME,
         McpServerConfig {
             command,
             args: SERVER_ARGS.to_vec(),
         },
     );
+    servers
+}
+
+fn json_config(command: &str) -> anyhow::Result<String> {
     Ok(format!(
         "{}\n",
-        crate::render::json::to_pretty(&McpServersConfig { mcp_servers })?
+        crate::render::json::to_pretty(&McpServersConfig {
+            mcp_servers: server_entry(command),
+        })?
+    ))
+}
+
+fn vscode_config(command: &str) -> anyhow::Result<String> {
+    Ok(format!(
+        "{}\n",
+        crate::render::json::to_pretty(&VscodeServersConfig {
+            servers: server_entry(command),
+        })?
     ))
 }
 
@@ -99,7 +122,6 @@ mod tests {
             McpClient::ClaudeCode,
             McpClient::Cursor,
             McpClient::Cline,
-            McpClient::Vscode,
             McpClient::Json,
         ] {
             let value = json_value(client, DEFAULT_COMMAND);
@@ -112,6 +134,23 @@ mod tests {
                 serde_json::json!(["serve"])
             );
         }
+    }
+
+    #[test]
+    fn vscode_uses_the_servers_key_it_actually_reads() {
+        let value = json_value(McpClient::Vscode, DEFAULT_COMMAND);
+        assert_eq!(
+            value["servers"]["biomcp"]["command"],
+            serde_json::Value::String("biomcp".to_string())
+        );
+        assert_eq!(
+            value["servers"]["biomcp"]["args"],
+            serde_json::json!(["serve"])
+        );
+        assert!(
+            value.get("mcpServers").is_none(),
+            "VS Code reads `servers` in mcp.json; `mcpServers` is silently ignored"
+        );
     }
 
     #[test]


### PR DESCRIPTION
`biomcp mcp-config --client vscode` emitted the `mcpServers` key that Claude Desktop, Claude Code, Cursor, and Cline use. VS Code reads `servers` in `mcp.json`.

The failure mode is the bad kind: the snippet is valid JSON, VS Code parses it without complaint, and then ignores it. The server never appears and nothing says why. A user following our own documentation gets a silent no-op.

Confirmed against the VS Code MCP documentation, which gives the top-level key as `servers` for both `.vscode/mcp.json` and the user profile config.

## Before / after

```console
$ biomcp mcp-config --client vscode      # before
{ "mcpServers": { "biomcp": { "command": "biomcp", "args": ["serve"] } } }

$ biomcp mcp-config --client vscode      # after
{ "servers": { "biomcp": { "command": "biomcp", "args": ["serve"] } } }
```

The other six clients are unchanged; `cursor` was checked as a control.

## Test restatement

`json_clients_use_biomcp_serve_by_default` pinned the old behavior — it asserted VS Code emits `mcpServers`. VS Code is removed from that list and given its own test, `vscode_uses_the_servers_key_it_actually_reads`, which also asserts `mcpServers` is absent so the two shapes cannot silently converge again. Written failing first, confirmed red for the right reason (`servers` resolved to `Null`), then fixed.

## Docs

`docs/getting-started/mcp-clients.md` carried the same wrong key in its copy-paste block. Corrected, with a note naming the file VS Code reads and warning that the wrong key fails silently.

## Changelog

Adds the entry for this fix, and one for the h2 0.4.16 bump (RUSTSEC-2026-0258) that #242 landed without recording.

## Gates, run locally

| Gate | Result |
| --- | --- |
| `make lint` | pass, exit 0 |
| `make test` | pass, 3009 Rust + 762 contract |
| `make spec` | pass, 36 + 8 |