### PR TITLE
Draft tickets 1022-1029 from the demo-run findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,14 @@
 
 ### Fixes
 
+- Emitted the `servers` key VS Code actually reads from `biomcp mcp-config
+  --client vscode`, instead of the `mcpServers` key the other stdio clients
+  use. VS Code parsed the old snippet without complaint and then ignored it,
+  so the server never appeared and nothing said why. Public MCP client docs
+  now show the same corrected shape.
+- Bumped the `h2` lockfile entry to 0.4.16 for RUSTSEC-2026-0258, which
+  accepted and queued empty DATA frames without limit. `h2` is a transitive
+  dependency of hyper and tonic, so no source change was needed.
 - Hardened CLI correctness before the next development candidate: local study
   discovery now treats a missing data directory as an empty catalog and drops
   invalid survival times; phenotype search has truthful 50-result paging and a

--- a/docs/getting-started/mcp-clients.md
+++ b/docs/getting-started/mcp-clients.md
@@ -151,11 +151,11 @@ Generate the VS Code config:
 biomcp mcp-config --client vscode
 ```
 
-Or add this server to your VS Code MCP configuration:
+Or add this server to `.vscode/mcp.json` in your workspace, or to the file VS Code opens with **MCP: Open User Configuration**. VS Code reads `servers` here, not the `mcpServers` key the other clients use — a snippet under the wrong key is valid JSON and is then silently ignored, so the server never shows up.
 
 ```json
 {
-  "mcpServers": {
+  "servers": {
     "biomcp": {
       "command": "biomcp",
       "args": ["serve"]

--- a/sdlc/tickets/drafts/1022-reach-gnomad-v4-from-an-rsid-instead-of-refusing.md
+++ b/sdlc/tickets/drafts/1022-reach-gnomad-v4-from-an-rsid-instead-of-refusing.md
@@ -1,0 +1,33 @@
+---
+flow: build
+priority: 8
+hold: draft for review; do not promote until Ian releases this
+---
+# Reach gnomAD v4 population data from an rsID
+
+`get variant rs334 population` returns population data on the published 0.8.25 release and returns `inapplicable` on the current development build. The message is "Direct gnomAD v4 population data requires a trustworthy GRCh38 coordinate." The same happens for `get variant "BRAF V600E" population`. This is a regression against shipped behavior, and it lands on the headline feature of the next minor release: an rsID is how most people name a variant, so the new gnomAD v4 output is currently unreachable by the most natural route into it.
+
+The refusal itself is correct and must stay. MyVariant.info answers an rsID lookup with a GRCh37 coordinate and reports `"genome_build": "GRCh37", "genome_build_provenance": "MyVariant.info provider default"`. Silently treating that as GRCh38 would report the wrong position's frequencies, which is worse than refusing. Nothing here should guess a coordinate or perform a liftover.
+
+What is missing is that a trustworthy GRCh38 coordinate is already obtainable without guessing. dbSNP returns one directly: for rs334 the SPDI is `NC_000011.10:5227001:T:A`, which is `NC_000011.10:g.5227002T>A` in the form this command already accepts and answers. BioMCP already treats dbSNP as a source and already prints a dbSNP link in this command's own output. So the fix is to resolve the identifier through a source that states the assembly, rather than to relax the check on a source that does not.
+
+`--assembly hg38` does not currently help, because it is rejected for anything that is not a chromosome-prefixed genomic coordinate: `Error: Invalid argument: --assembly only applies to chromosome-prefixed genomic coordinates`. Setting `BIOMCP_DEFAULT_ASSEMBLY=hg38` has no effect on this path either. Decide deliberately whether either of those should apply once an rsID resolves to a real GRCh38 coordinate, and say so in the design.
+
+## Done when
+
+- `get variant rs334 population` returns gnomAD v4 population data, with the same exome and genome separation, allele counts, ancestry rows, FAF95, and filter status that the explicit `NC_` accession form already returns today.
+- The values returned for a resolved rsID are identical to the values returned when the equivalent GRCh38 accession is supplied directly.
+- The resolved coordinate's assembly is stated in the response along with the source that supplied it, so a reader can tell resolution happened and who is accountable for it.
+- An identifier that genuinely cannot be resolved to a GRCh38 coordinate from an assembly-stating source still returns `inapplicable` with a message naming what was tried. No liftover is performed anywhere.
+- A GRCh37-only answer from a provider is never treated as GRCh38.
+
+## Existing tests that pin this
+
+Restatement is authorized for the files below by name, to the extent they assert that an rsID input yields an `inapplicable` population outcome. Do not weaken any assertion that a GRCh37 coordinate is refused as GRCh38 — that is the safety property this ticket preserves.
+
+- Any test asserting `inapplicable` for the population section on rsID input under `tests/` — the design stage must name the exact files it touches in its commit message.
+- Spec pages under `spec/` covering `get variant ... population`.
+
+## Verification note
+
+The reference values were confirmed against the gnomAD GraphQL API for `11-5227002-T-A` in `gnomad_r4` on 2026-08-19: exomes AC 2335, AN 1458356, 31 homozygotes, grpmax FAF95 0.05474387 (afr); genomes AC 1937, AN 152294, grpmax FAF95 0.04188667 (afr). The development build already reproduces every one of these exactly when given the GRCh38 accession, so the data path is correct and only the identifier path is at fault.

--- a/sdlc/tickets/drafts/1023-stop-printing-zero-counts-for-a-source-that-was-never-reached.md
+++ b/sdlc/tickets/drafts/1023-stop-printing-zero-counts-for-a-source-that-was-never-reached.md
@@ -1,0 +1,48 @@
+---
+flow: build
+priority: 7
+hold: draft for review; do not promote until Ian releases this
+---
+# Stop printing zero counts for a source that was never reached
+
+When an optional source is unreachable, the Markdown body still opens with counts of zero and a sentence saying nothing was returned, and only corrects itself much further down. With CIViC pointed at a closed port, `get gene BRAF civic` prints this at lines 4 to 6:
+
+```
+- Evidence Items: 0
+- Assertions: 0
+No CIViC records returned for this gene query.
+```
+
+and then at line 23, below the `More:` and `See also:` navigation blocks, prints the truth:
+
+```
+**CIViC status (CIViC):** unavailable; no conclusion can be drawn — CIViC gene evidence is unavailable.
+```
+
+The honest line is present and the JSON contract is already correct, so this is not a missing capability. The defect is that the output asserts a false fact first and retracts it nineteen lines later, with two blocks of unrelated navigation in between. A person skimming, or an agent reading the response top to bottom, takes the zeros. For a gene like BRAF the wrong reading is "no clinical evidence exists," which is the most damaging conclusion this tool could lead someone to.
+
+A genuinely empty result from a source that answered must remain clearly different from a source that did not answer, and both must be legible from the top of the section without reading to the end.
+
+Disease survival has the same shape with two strings that are easy to mistake for each other: "SEER survival data not available for this condition." and "No SEER survival data available." Settle in the design which of those means absence and which means unavailability, and make the difference obvious rather than a matter of word order.
+
+## The hard choice to settle
+
+Either suppress the count lines entirely when the outcome is not `data`, or keep them and move the status line above them. Suppression is cleaner to read but removes a line some existing caller may parse; reordering is safer but leaves a reader briefly holding a zero. Pick one, apply it the same way to every section that reports a source outcome, and say in the design why.
+
+## Done when
+
+- A section whose outcome is `unavailable` does not present a count of zero, or a sentence asserting that nothing was returned, ahead of the statement that the source could not be reached.
+- The unavailability statement appears within the section's own body, before any `More:` or `See also:` navigation block.
+- A section whose outcome is genuinely `empty` still reads as a real, trustworthy zero and is not confusable with unavailability.
+- The same rule holds for the CIViC gene section and the disease survival section, and any other section that reports a source outcome the same way.
+- The JSON contract is unchanged: `data`, `empty`, `unavailable`, and `inapplicable` keep their current meanings and a failed source still receives no credit in the `sources` list.
+- The MCP Markdown response an agent receives carries the same corrected ordering as the CLI.
+
+## Reproduction
+
+```
+BIOMCP_CIVIC_BASE=http://127.0.0.1:9 biomcp get gene BRAF civic   # unavailable
+biomcp get gene OR4F5 civic                                       # genuinely empty
+```
+
+Both exit 0 today, which is correct; the difference must be readable from the top of the section rather than from the exit code.

--- a/sdlc/tickets/drafts/1024-give-the-mcp-tool-catalog-real-headroom-under-its-budget.md
+++ b/sdlc/tickets/drafts/1024-give-the-mcp-tool-catalog-real-headroom-under-its-budget.md
@@ -1,0 +1,27 @@
+---
+flow: build
+priority: 6
+hold: draft for review; do not promote until Ian releases this
+---
+# Give the MCP tool catalog real headroom under its budget
+
+The development build's MCP tool catalog measures 15,704 bytes and 3,974 tokens against an enforced ceiling of 16,000 bytes and 4,000 tokens. That is 26 tokens of headroom. The next typed tool, or one more sentence in any existing tool description, fails the gate — and it fails as a budget violation on whatever unrelated ticket happens to add it, which is a confusing place to discover that the real problem is a catalog with no room in it.
+
+The budget itself is a good idea and should stay. Every agent that connects pays for this catalog on every session, so a hard ceiling is the right instrument. The problem is that the ceiling is currently indistinguishable from a tripwire.
+
+Measured on 2026-08-19: the published 0.8.25 release is 4 tools and 21,701 bytes, and the development build is 7 tools and 15,704 bytes, so the direction of travel is good — more capability for a smaller catalog. This ticket is about keeping it that way rather than reversing it.
+
+## The hard choice to settle
+
+Decide whether the answer is to reclaim space inside the current catalog, to raise the ceiling with a stated reason, or to warn before failing. Reclaiming space keeps the discipline but has a floor; raising the ceiling is honest but needs a defensible number rather than a round one; warning first is the gentlest but does not by itself create room. Pick one and justify it in the design. Do not simply raise the number to whatever the current catalog happens to measure, because that sets the ceiling to today's accident.
+
+## Done when
+
+- Adding one typical new typed tool, or a normal-length sentence to an existing tool description, does not fail the budget gate.
+- When the gate does fail, the failure message states the current measurement, the ceiling, and which tool descriptions are largest, so the person who hit it can act without going to read the measurement script.
+- The catalog measurement is reported on every run of the gate, not only when it fails, so the trend is visible before it becomes a wall.
+- The chosen ceiling is written down with the reasoning behind it, so a later reader can tell whether it was measured or guessed.
+
+## Related
+
+The measurement script `scripts/measure-mcp-tools.py` currently depends on the committed tokenizer cache path and on being run from a repository checkout, so it cannot easily be pointed at an arbitrary installed binary. Making it runnable against any binary would let this be checked outside CI. Treat that as in scope only if it falls out naturally; otherwise leave it and say so.

--- a/sdlc/tickets/drafts/1025-correct-the-published-tool-catalog-figures.md
+++ b/sdlc/tickets/drafts/1025-correct-the-published-tool-catalog-figures.md
@@ -1,0 +1,18 @@
+---
+flow: quickfix
+priority: 5
+hold: draft for review; do not promote until Ian releases this
+---
+# Correct the published tool catalog figures
+
+`docs/blog/we-deleted-35-tools.md` quotes a tool catalog of 6,707 bytes and 1,628 tokens. Measured on 2026-08-19, the development build's catalog is 15,704 bytes and 3,974 tokens, and the published 0.8.25 release is 21,701 bytes and 5,599 tokens. The published figure is not close to either, and it is the number a reader would quote back at us.
+
+The documentation also states a 16,000-byte and 4,000-token budget without making clear that the budget is enforced on the development branch and that the currently installed public release is above it. A reader who installs 0.8.25, measures its catalog, and compares it against the documented budget finds a discrepancy the documentation does not explain.
+
+Correct the figures and say plainly which build each number describes. Do not delete the comparison — the story the post tells is real and the current numbers still support it.
+
+## Done when
+
+- Every catalog byte and token figure in public documentation matches a measurement of a named build, and names which build it measured.
+- Where a budget is quoted, the text says what it applies to and which builds it is enforced on.
+- No public figure claims the currently published release is inside a budget it is outside of.

--- a/sdlc/tickets/drafts/1026-make-gene-cspec-and-variant-erepo-flags-do-what-they-say.md
+++ b/sdlc/tickets/drafts/1026-make-gene-cspec-and-variant-erepo-flags-do-what-they-say.md
@@ -1,0 +1,23 @@
+---
+flow: quickfix
+priority: 4
+hold: draft for review; do not promote until Ian releases this
+---
+# Make gene cspec and variant erepo flags do what they say
+
+Three flags on the new ClinGen commands do not behave the way their presence implies, on the development build:
+
+`gene cspec BRCA1` and `--json gene cspec BRCA1` produce byte-identical JSON. The command ignores `--json` because it has no Markdown rendering of the manifest or the criteria list at all, even though `gene cspec BRCA1 --files` does render Markdown. A global modifier that changes nothing is worse than one that is rejected, because the caller believes it took effect.
+
+`variant erepo --detail` produces identical Markdown with and without the flag. The narrative summary and source URL it implies only appear under `--json`.
+
+`variant erepo --input` refuses to run without `--json`, reporting `Error: Invalid argument: variant erepo --input requires --json`, while the single-CAid form has no such restriction. Either the batch form should render Markdown like its sibling, or the asymmetry should be explained where a caller will see it.
+
+Settle each of the three the same way: either the flag does something, or it is rejected with a message that says why. Silent no-ops are the outcome to eliminate.
+
+## Done when
+
+- `--json` on `gene cspec` either changes the output or is rejected with a message naming what is unsupported.
+- `variant erepo --detail` either changes the Markdown or is rejected in the Markdown path.
+- The `--input` restriction is either lifted or explained in help text and in the error itself.
+- No flag on these commands is accepted and then ignored.

--- a/sdlc/tickets/drafts/1027-stop-flag-order-from-silently-changing-a-command.md
+++ b/sdlc/tickets/drafts/1027-stop-flag-order-from-silently-changing-a-command.md
@@ -1,0 +1,18 @@
+---
+flow: quickfix
+priority: 4
+hold: draft for review; do not promote until Ian releases this
+---
+# Stop flag order from silently changing a command
+
+`get article 42125600 assets --asset-view coverage` fails with `Invalid argument: assets is a standalone JSON-only article section; do not combine it with other sections`. Moving the same flag before the section, `get article 42125600 --asset-view coverage assets`, works. The two forms differ only in argument order, and nothing tells the caller that order matters here.
+
+The error compounds it by describing a problem the caller does not have. Nothing was combined with another section; the flag's value was parsed as one. A caller reading that message looks for a second section they never asked for.
+
+The error object also comes back carrying `"assets": []` alongside the error. That is the shape a careless caller reads as "this article has no assets," which is the same class of mistake as reporting zero for a source that was never reached.
+
+## Done when
+
+- Both argument orders either work identically, or the rejected one fails with a message naming the actual cause.
+- No error message for this command describes combining sections unless sections were actually combined.
+- A response carrying an error does not also carry an empty collection under the key a successful call would populate, for this command's error paths.

--- a/sdlc/tickets/drafts/1028-do-not-dump-raw-binary-to-a-terminal.md
+++ b/sdlc/tickets/drafts/1028-do-not-dump-raw-binary-to-a-terminal.md
@@ -1,0 +1,21 @@
+---
+flow: quickfix
+priority: 3
+hold: draft for review; do not promote until Ian releases this
+---
+# Do not dump raw binary to a terminal
+
+`get article <id> asset <key>` writes the retrieved bytes straight to standard output with no warning. Fetching a `.docx` supplement fills the terminal with ZIP container bytes, which at best is unreadable and at worst leaves the terminal in a broken state.
+
+Writing bytes to standard output is the right behavior when the caller is piping them somewhere. The problem is doing it when the caller is a person looking at a terminal, and having no obvious way to ask for a file instead.
+
+## The hard choice to settle
+
+Decide between refusing to write binary to an interactive terminal unless the caller opts in, and adding an explicit destination flag, and doing both. Whichever is chosen must keep piping to a file or another process working exactly as it does now, because that is the case the command exists to serve.
+
+## Done when
+
+- Running the command interactively against a binary asset does not fill the terminal with raw bytes by default.
+- Redirecting or piping the command's output still produces the exact bytes it produces today, unchanged.
+- The help text says where the bytes go and how to change that.
+- Whatever guard is added does not depend on the file extension, since the media type is already known from the manifest.

--- a/sdlc/tickets/drafts/1029-use-one-vocabulary-for-a-sections-outcome.md
+++ b/sdlc/tickets/drafts/1029-use-one-vocabulary-for-a-sections-outcome.md
@@ -1,0 +1,16 @@
+---
+flow: quickfix
+priority: 3
+hold: draft for review; do not promote until Ian releases this
+---
+# Use one vocabulary for a section's outcome
+
+In a single response on the development build, the `population` object reports `"status": "missing"` while `section_outcomes.population` reports `"outcome": "inapplicable"` for the same condition. Two keys, two vocabularies, one state.
+
+The four-state contract of `data`, `empty`, `unavailable`, and `inapplicable` is the valuable thing in this design, and it is undermined by a second word appearing in the same payload for the same fact. A caller writing against the contract has to learn which key to trust, and a caller who guesses wrong gets a state that is not in the documented set.
+
+## Done when
+
+- A given section's outcome is reported with one vocabulary across the whole response.
+- Any key that survives uses a value from the documented four-state set, or is documented as a distinct concept with its reason for existing stated.
+- The documented contract and the emitted payload agree, and a test pins that agreement so a third vocabulary cannot appear later.

--- a/src/cli/mcp_config.rs
+++ b/src/cli/mcp_config.rs
@@ -12,6 +12,14 @@ struct McpServersConfig<'a> {
     mcp_servers: std::collections::BTreeMap<&'static str, McpServerConfig<'a>>,
 }
 
+/// VS Code reads `servers` in `mcp.json`, not the `mcpServers` key the other
+/// clients use. A snippet under the wrong key parses fine and is then ignored,
+/// so the server simply never appears.
+#[derive(Serialize)]
+struct VscodeServersConfig<'a> {
+    servers: std::collections::BTreeMap<&'static str, McpServerConfig<'a>>,
+}
+
 #[derive(Serialize)]
 struct McpServerConfig<'a> {
     command: &'a str,
@@ -39,24 +47,39 @@ fn render(client: Option<McpClient>, command: &str) -> anyhow::Result<String> {
         Some(McpClient::ClaudeCode) => json_config(command)?,
         Some(McpClient::Cursor) => json_config(command)?,
         Some(McpClient::Cline) => json_config(command)?,
-        Some(McpClient::Vscode) => json_config(command)?,
+        Some(McpClient::Vscode) => vscode_config(command)?,
         Some(McpClient::Json) => json_config(command)?,
         None => discovery_page(),
     })
 }
 
-fn json_config(command: &str) -> anyhow::Result<String> {
-    let mut mcp_servers = std::collections::BTreeMap::new();
-    mcp_servers.insert(
+fn server_entry(command: &str) -> std::collections::BTreeMap<&'static str, McpServerConfig<'_>> {
+    let mut servers = std::collections::BTreeMap::new();
+    servers.insert(
         SERVER_NAME,
         McpServerConfig {
             command,
             args: SERVER_ARGS.to_vec(),
         },
     );
+    servers
+}
+
+fn json_config(command: &str) -> anyhow::Result<String> {
     Ok(format!(
         "{}\n",
-        crate::render::json::to_pretty(&McpServersConfig { mcp_servers })?
+        crate::render::json::to_pretty(&McpServersConfig {
+            mcp_servers: server_entry(command),
+        })?
+    ))
+}
+
+fn vscode_config(command: &str) -> anyhow::Result<String> {
+    Ok(format!(
+        "{}\n",
+        crate::render::json::to_pretty(&VscodeServersConfig {
+            servers: server_entry(command),
+        })?
     ))
 }
 
@@ -99,7 +122,6 @@ mod tests {
             McpClient::ClaudeCode,
             McpClient::Cursor,
             McpClient::Cline,
-            McpClient::Vscode,
             McpClient::Json,
         ] {
             let value = json_value(client, DEFAULT_COMMAND);
@@ -112,6 +134,23 @@ mod tests {
                 serde_json::json!(["serve"])
             );
         }
+    }
+
+    #[test]
+    fn vscode_uses_the_servers_key_it_actually_reads() {
+        let value = json_value(McpClient::Vscode, DEFAULT_COMMAND);
+        assert_eq!(
+            value["servers"]["biomcp"]["command"],
+            serde_json::Value::String("biomcp".to_string())
+        );
+        assert_eq!(
+            value["servers"]["biomcp"]["args"],
+            serde_json::json!(["serve"])
+        );
+        assert!(
+            value.get("mcpServers").is_none(),
+            "VS Code reads `servers` in mcp.json; `mcpServers` is silently ignored"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Eight ticket drafts from the 2026-08-19 exploratory run. **All held in `sdlc/tickets/drafts/` with a `hold:` line — none are promoted.** Sync does not read `drafts/`, so nothing here reaches the board.

Every finding was reproduced independently before it was filed, and the two that did not survive that check are deliberately absent.

| Ticket | Flow | What |
| --- | --- | --- |
| 1022 | build | gnomAD v4 unreachable from an rsID — regression against 0.8.25 |
| 1023 | build | unavailable sources print a zero count before the correction |
| 1024 | build | MCP tool catalog sits 26 tokens under its ceiling |
| 1025 | quickfix | published catalog figures stale by roughly a factor of two |
| 1026 | quickfix | `gene cspec` / `variant erepo` flags accepted and ignored |
| 1027 | quickfix | flag order silently changes a command, misleading error |
| 1028 | quickfix | raw binary written to an interactive terminal |
| 1029 | quickfix | two vocabularies for one section outcome in one payload |

## The one that matters for 0.9

**1022.** `get variant rs334 population` works on 0.8.25 and returns `inapplicable` on the development build. The refusal is correct — MyVariant answers an rsID with a GRCh37 coordinate and says so — but the consequence is that the release headline feature is unreachable by the most common way people name a variant.

The fix needs no liftover guess. dbSNP returns the GRCh38 coordinate authoritatively (`NC_000011.10:5227001:T:A` for rs334), which is exactly the form the command already accepts and answers correctly.

The ticket carries reference values confirmed against the gnomAD GraphQL API on 2026-08-19: exomes AC 2335 / AN 1458356 / 31 homozygotes / grpmax FAF95 0.05474387 (afr), genomes AC 1937 / AN 152294 / grpmax FAF95 0.04188667 (afr). The development build already reproduces all of these exactly from the GRCh38 accession, so the data path is sound and only the identifier path is at fault.

## Two claims that did not survive checking, and are not filed

- **CIViC Markdown was reported as destroying the "no evidence" versus "source down" distinction. It does not.** The unavailable case does emit an explicit status line and the genuinely-empty case does not. The real defect is narrower — a false zero printed nineteen lines above the correction — and that is what 1023 says.
- **Missing author affiliations were reported as a BioMCP weakness.** A direct query to the Semantic Scholar API returns nine "Bert Vogelstein" records, all with `affiliations: []` and no ORCID. BioMCP is accurately reporting an empty source. No ticket.

Supporting write-ups are in the notes folder and are not authoritative; these drafts are where the findings become real.