### PR TITLE
Draft tickets 1030-1037, the remaining demo-run findings

### DIFF
--- a/sdlc/tickets/drafts/1022-reach-gnomad-v4-from-an-rsid-instead-of-refusing.md
+++ b/sdlc/tickets/drafts/1022-reach-gnomad-v4-from-an-rsid-instead-of-refusing.md
@@ -23,10 +23,14 @@ What is missing is that a trustworthy GRCh38 coordinate is already obtainable wi
 
 ## Existing tests that pin this
 
-Restatement is authorized for the files below by name, to the extent they assert that an rsID input yields an `inapplicable` population outcome. Do not weaken any assertion that a GRCh37 coordinate is refused as GRCh38 — that is the safety property this ticket preserves.
+Restatement is authorized in these files, for these tests by name, only to the extent they assert that an rsID or a gene-and-change input yields an `inapplicable` population outcome:
 
-- Any test asserting `inapplicable` for the population section on rsID input under `tests/` — the design stage must name the exact files it touches in its commit message.
-- Spec pages under `spec/` covering `get variant ... population`.
+- `src/entities/variant/get/tests.rs` — `population_request_requires_a_grch38_genomic_coordinate`
+- `src/render/markdown/variant/tests.rs` — `variant_population_markdown_keeps_missing_status_compact`
+
+No other test file is authorized. Do not weaken any assertion that a GRCh37 coordinate is refused as GRCh38 — that is the safety property this ticket preserves, and it must still hold at the end.
+
+If the design stage finds a further shipped assertion that pins the old refusal and is not named above, stop and say so in the design output rather than restating it; that is a ticket amendment, not a design decision.
 
 ## Verification note
 

--- a/sdlc/tickets/drafts/1023-stop-printing-zero-counts-for-a-source-that-was-never-reached.md
+++ b/sdlc/tickets/drafts/1023-stop-printing-zero-counts-for-a-source-that-was-never-reached.md
@@ -46,3 +46,12 @@ biomcp get gene OR4F5 civic                                       # genuinely em
 ```
 
 Both exit 0 today, which is correct; the difference must be readable from the top of the section rather than from the exit code.
+
+## Existing tests that pin this
+
+The current wording and ordering are asserted in shipped tests. Restatement is authorized in these files, for these tests by name, only to the extent they assert that a no-records sentence or a zero count appears for a section whose outcome is not `data`:
+
+- `src/render/markdown/gene/tests/rendering.rs` — `gene_markdown_section_only_shows_new_gene_enrichment_sections`, which asserts the literal sentences `No GTEx expression records returned`, `No Human Protein Atlas records returned`, `No DGIdb interactions returned`, and `No ClinGen records returned`
+- `src/render/markdown/disease/tests/rendering.rs` and `src/render/markdown/disease/tests/extended.rs`, for the SEER survival wording only
+
+No other test file is authorized. Assertions that a genuinely `empty` section reads as a real zero must survive unchanged — that is the distinction this ticket exists to protect. If the design stage finds a further shipped assertion that pins the old ordering and is not named above, say so in the design output rather than restating it.

--- a/sdlc/tickets/drafts/1024-give-the-mcp-tool-catalog-real-headroom-under-its-budget.md
+++ b/sdlc/tickets/drafts/1024-give-the-mcp-tool-catalog-real-headroom-under-its-budget.md
@@ -1,6 +1,7 @@
 ---
 flow: build
 priority: 6
+deps: ["1030"]
 hold: draft for review; do not promote until Ian releases this
 ---
 # Give the MCP tool catalog real headroom under its budget
@@ -25,3 +26,9 @@ Decide whether the answer is to reclaim space inside the current catalog, to rai
 ## Related
 
 The measurement script `scripts/measure-mcp-tools.py` currently depends on the committed tokenizer cache path and on being run from a repository checkout, so it cannot easily be pointed at an arbitrary installed binary. Making it runnable against any binary would let this be checked outside CI. Treat that as in scope only if it falls out naturally; otherwise leave it and say so.
+
+## Existing tests that pin this
+
+The budget gate itself is `tests/test_mcp_tool_catalog.py`, in `test_real_tools_list_stays_within_context_budget`, which asserts `tools/list UTF-8 bytes <= 16_000`, `tools/list cl100k_base tokens <= 4_000`, and `biomcp description UTF-8 bytes <= 4_000`. Restatement is authorized in that file, for that test by name, since changing the ceiling or the failure reporting is the point of this ticket. No other test file is authorized.
+
+Whatever the chosen ceiling is, the assertion must remain a hard failure, not a warning — the gate keeps its teeth.

--- a/sdlc/tickets/drafts/1025-correct-the-published-tool-catalog-figures.md
+++ b/sdlc/tickets/drafts/1025-correct-the-published-tool-catalog-figures.md
@@ -16,3 +16,9 @@ Correct the figures and say plainly which build each number describes. Do not de
 - Every catalog byte and token figure in public documentation matches a measurement of a named build, and names which build it measured.
 - Where a budget is quoted, the text says what it applies to and which builds it is enforced on.
 - No public figure claims the currently published release is inside a budget it is outside of.
+
+## The stale assertion
+
+`tests/test_documentation_consistency_audit_contract.py`, in `test_blog_try_it_and_install_copy_are_consistent`, asserts the literal string `1,628 \`cl100k_base\` tokens at the 0932 snapshot` and the literal string `16,000 bytes and 4,000 tokens`. The first of those pins a figure that is no longer true of any build, so that assertion is itself part of the defect and may be restated with the corrected figure. Say so in the commit message, as the repair stage requires. No other test file may be changed.
+
+Two other tests read the same blog file but do not assert any figure — `tests/test_mcp_tool_catalog.py` checks only that each tool name appears, and `tests/test_public_install_docs_contract.py` checks only headings and install commands. Neither should need touching; if either goes red, that is a signal the edit went wider than the figures.

--- a/sdlc/tickets/drafts/1026-make-gene-cspec-and-variant-erepo-flags-do-what-they-say.md
+++ b/sdlc/tickets/drafts/1026-make-gene-cspec-and-variant-erepo-flags-do-what-they-say.md
@@ -1,5 +1,5 @@
 ---
-flow: quickfix
+flow: build
 priority: 4
 hold: draft for review; do not promote until Ian releases this
 ---

--- a/sdlc/tickets/drafts/1027-stop-flag-order-from-silently-changing-a-command.md
+++ b/sdlc/tickets/drafts/1027-stop-flag-order-from-silently-changing-a-command.md
@@ -1,5 +1,5 @@
 ---
-flow: quickfix
+flow: build
 priority: 4
 hold: draft for review; do not promote until Ian releases this
 ---

--- a/sdlc/tickets/drafts/1028-do-not-dump-raw-binary-to-a-terminal.md
+++ b/sdlc/tickets/drafts/1028-do-not-dump-raw-binary-to-a-terminal.md
@@ -1,5 +1,5 @@
 ---
-flow: quickfix
+flow: build
 priority: 3
 hold: draft for review; do not promote until Ian releases this
 ---

--- a/sdlc/tickets/drafts/1029-use-one-vocabulary-for-a-sections-outcome.md
+++ b/sdlc/tickets/drafts/1029-use-one-vocabulary-for-a-sections-outcome.md
@@ -1,6 +1,7 @@
 ---
-flow: quickfix
+flow: build
 priority: 3
+deps: ["1022", "1035"]
 hold: draft for review; do not promote until Ian releases this
 ---
 # Use one vocabulary for a section's outcome
@@ -14,3 +15,14 @@ The four-state contract of `data`, `empty`, `unavailable`, and `inapplicable` is
 - A given section's outcome is reported with one vocabulary across the whole response.
 - Any key that survives uses a value from the documented four-state set, or is documented as a distinct concept with its reason for existing stated.
 - The documented contract and the emitted payload agree, and a test pins that agreement so a third vocabulary cannot appear later.
+
+## Existing tests that pin this
+
+The `missing` vocabulary is asserted in shipped tests. Restatement is authorized in these files, for these tests by name, only to the extent they assert the string `missing` as a population status:
+
+- `src/render/markdown/variant/tests.rs` — `variant_population_markdown_keeps_missing_status_compact`
+- `src/entities/variant/get/tests.rs` — `population_status_json_keeps_explicit_null_exome_and_genome_results`
+
+The producing code is `GnomadPopulationStatus` in `src/entities/variant/get.rs`, and the documented contract is `spec/entity/section-outcomes.md`, which may be updated to match whichever vocabulary is chosen.
+
+No other test file is authorized. If the design stage finds a further shipped assertion naming a fifth state and it is not listed above, say so in the design output rather than restating it.

--- a/sdlc/tickets/drafts/1030-let-the-cli-show-the-mcp-tool-catalog.md
+++ b/sdlc/tickets/drafts/1030-let-the-cli-show-the-mcp-tool-catalog.md
@@ -1,0 +1,23 @@
+---
+flow: build
+priority: 7
+hold: draft for review; do not promote until Ian releases this
+---
+# Let the CLI show the MCP tool catalog
+
+There is no way to see the tool catalog an agent receives without writing a JSON-RPC client. Two separate people hit this on 2026-08-19: the exploratory run had to hand-write a client to compare the two builds, and the follow-up verification had to write a second one. Both were rewriting `scripts/measure-mcp-tools.py`, which cannot easily be pointed at an arbitrary installed binary because it depends on the committed tokenizer cache path and on running inside a repository checkout.
+
+The catalog is the real interface for every agent that connects. It carries the tool names, the typed schemas, the enums, the descriptions, and the read-only annotations, and it is what the budget gate measures. Something that important should be inspectable from the binary itself, by a user who has installed it and has no checkout.
+
+This is also the cheapest available fix to a testing gap. Today the gates check BioMCP against fixtures inside the repository. A subcommand that prints the catalog would let the budget, the annotations, and the schema shape be checked against a real installed binary from outside, which is where a user's experience actually lives.
+
+## Done when
+
+- A user with only the installed binary can print the MCP tool catalog, including each tool's name, description, input schema, and annotations.
+- The output is machine-readable, so it can be diffed between builds and asserted against in a check that does not need a repository checkout.
+- The byte and token measurements the budget gate uses can be reproduced from that output, without the committed tokenizer cache or the repository working directory.
+- Printing the catalog does not require starting a server or speaking JSON-RPC.
+
+## Note on scope
+
+Whether `scripts/measure-mcp-tools.py` is then reduced to a thin wrapper, or removed in favour of the subcommand, is a design decision. Say which was chosen and why.

--- a/sdlc/tickets/drafts/1031-tighten-the-variant-erepo-typed-schema.md
+++ b/sdlc/tickets/drafts/1031-tighten-the-variant-erepo-typed-schema.md
@@ -1,0 +1,17 @@
+---
+flow: build
+priority: 5
+hold: draft for review; do not promote until Ian releases this
+---
+# Tighten the variant erepo typed schema
+
+The typed MCP tools are described as an interface an agent can rely on, with enums and bounds that stop a model guessing. `variant_erepo` does not hold that line. Its fields are largely nullable strings with no enums, and the mutual exclusivity of `caid`, `caids`, and `gene` is not expressed in the schema at all — an agent can supply all three and only discovers the problem from a runtime error.
+
+The `search` tool shows what the standard should be: per-entity constants, enumerated sections, and bounded page sizes. The value of a typed catalog comes from being uniform. One loose tool teaches a model that the schemas are advisory, and the cost is paid in wasted turns across every tool.
+
+## Done when
+
+- `variant_erepo`'s schema expresses which of `caid`, `caids`, and `gene` may appear together, so an invalid combination is rejected before a call is made rather than after.
+- Fields with a known closed set of values carry that set in the schema.
+- Bounded fields carry their bounds.
+- A survey of the other typed tools is included in the design, naming any that fall below the `search` standard, so it is clear whether this is one outlier or a pattern. Fixing the others is not in scope unless the design shows it is the same change.

--- a/sdlc/tickets/drafts/1032-say-how-many-assertions-a-gene-has-when-a-variant-has-none.md
+++ b/sdlc/tickets/drafts/1032-say-how-many-assertions-a-gene-has-when-a-variant-has-none.md
@@ -24,3 +24,7 @@ Take care not to overstate what the count means. It is the number of assertions 
 ## Related
 
 `sdlc/tickets/drafts/1023` covers the neighbouring problem of a zero count printed for a source that was never reached. These are different: 1023 is about an unreachable source, this is about a source that answered honestly with nothing.
+
+## Existing tests that pin this
+
+None. The sentence is written at `src/cli/variant/erepo.rs:166` and no shipped test asserts it — `tests/unit/cli/variant.rs` covers only the `--gene` bounds and mutual exclusivity, which this ticket does not touch. Checked 2026-08-20. No restatement is needed or authorized.

--- a/sdlc/tickets/drafts/1032-say-how-many-assertions-a-gene-has-when-a-variant-has-none.md
+++ b/sdlc/tickets/drafts/1032-say-how-many-assertions-a-gene-has-when-a-variant-has-none.md
@@ -1,0 +1,26 @@
+---
+flow: build
+priority: 6
+hold: draft for review; do not promote until Ian releases this
+---
+# Say how many assertions a gene has when a variant has none
+
+`variant erepo` on an allele with no ClinGen expert assertion returns "No expert assertions were returned." That is accurate and it is the common case, which is the problem. Measured against ClinVar on 2026-08-19, the ClinGen Evidence Repository holds 81 assertions for BRCA1 against 16,061 ClinVar records, 108 for APC against 17,168, 182 for TP53 against 4,019, and 229 for PTEN against 4,205. An arbitrary variant is far more likely to have no assertion than to have one.
+
+So the first thing a new user sees, for most variants they try, is a blank. Nothing in that message distinguishes "expert curation exists for this gene but not this variant" from "this gene has no expert panel" from "something went wrong." All three read identically, and the most likely reading is the wrong one.
+
+BioMCP already has a gene-level query that returns the count. Naming it turns a dead end into a usable fact: expert curation exists here, this particular variant has not been adjudicated.
+
+Take care not to overstate what the count means. It is the number of assertions the repository holds for that gene, not a coverage percentage and not a statement about the variant's pathogenicity. Absence of an assertion is not evidence of benignity, and the wording must not imply it is.
+
+## Done when
+
+- An empty assertion result for a variant states how many assertions the repository holds for that variant's gene, when the gene is known.
+- The wording distinguishes an uncurated variant in a curated gene from a gene with no expert curation at all.
+- The message does not imply anything about the variant's classification, in either direction.
+- The extra fact does not turn a successful empty result into an error, and does not change the exit code.
+- If the gene-level lookup fails or is unavailable, the original message is still returned rather than an error.
+
+## Related
+
+`sdlc/tickets/drafts/1023` covers the neighbouring problem of a zero count printed for a source that was never reached. These are different: 1023 is about an unreachable source, this is about a source that answered honestly with nothing.

--- a/sdlc/tickets/drafts/1033-accept-a-short-version-for-gene-cspec.md
+++ b/sdlc/tickets/drafts/1033-accept-a-short-version-for-gene-cspec.md
@@ -1,5 +1,5 @@
 ---
-flow: quickfix
+flow: build
 priority: 3
 hold: draft for review; do not promote until Ian releases this
 ---

--- a/sdlc/tickets/drafts/1033-accept-a-short-version-for-gene-cspec.md
+++ b/sdlc/tickets/drafts/1033-accept-a-short-version-for-gene-cspec.md
@@ -1,0 +1,22 @@
+---
+flow: quickfix
+priority: 3
+hold: draft for review; do not promote until Ian releases this
+---
+# Accept a short version for gene cspec
+
+Selecting a criteria specification version requires pasting a full resource IRI copied out of the manifest, roughly ninety characters:
+
+```
+gene cspec BRCA1 --version 'https://cspec.genome.network/cspec/SequenceVariantInterpretation/id/GN092/version/1.2.1'
+```
+
+The manifest already lists the available versions, and the version number at the end of each IRI is what a person actually means. Accepting `--version 1.2.1` would remove a copy-paste step from a command a curation team runs repeatedly, and would make the command reasonable to type from memory or to generate in a script.
+
+The full IRI must keep working, because it is unambiguous and it is what the manifest returns.
+
+## Done when
+
+- `--version 1.2.1` selects the matching specification for the named gene.
+- The full resource IRI continues to work exactly as it does today.
+- A short version that matches nothing, or that is ambiguous for the gene, fails with a message listing the versions that are available.

--- a/sdlc/tickets/drafts/1034-separate-authors-from-affiliations-in-article-indexing.md
+++ b/sdlc/tickets/drafts/1034-separate-authors-from-affiliations-in-article-indexing.md
@@ -1,0 +1,22 @@
+---
+flow: quickfix
+priority: 3
+hold: draft for review; do not promote until Ian releases this
+---
+# Separate authors from affiliations in article indexing
+
+`get article <id> indexing` renders author names and their affiliations as sibling bullets with nothing distinguishing them, so the output reads as a list of authors where every second entry is an institution:
+
+```
+- Keith T Flaherty
+- Massachusetts General Hospital Cancer Center, Boston, USA. kflaherty@partners.org
+```
+
+A reader cannot tell how many authors a paper has, and anything parsing the list gets institutions mixed in with people. The underlying data already distinguishes the two — the affiliation is attached to the author — so this is a rendering fault rather than a missing field.
+
+## Done when
+
+- An author and that author's affiliation are visually distinguishable in the rendered output.
+- The number of authors can be counted correctly from the output.
+- An author with no affiliation, and an author with several, both render sensibly.
+- The typed JSON form keeps the association between an author and their affiliations.

--- a/sdlc/tickets/drafts/1034-separate-authors-from-affiliations-in-article-indexing.md
+++ b/sdlc/tickets/drafts/1034-separate-authors-from-affiliations-in-article-indexing.md
@@ -20,3 +20,12 @@ A reader cannot tell how many authors a paper has, and anything parsing the list
 - The number of authors can be counted correctly from the output.
 - An author with no affiliation, and an author with several, both render sensibly.
 - The typed JSON form keeps the association between an author and their affiliations.
+
+## Where this lives
+
+The sibling bullet is written in `src/render/markdown/author.rs`, which emits `- {affiliation}` at the same list level as the author name. Restatement is authorized in these files, for these tests by name, only to the extent they assert the current flat bullet shape:
+
+- `src/render/markdown/author.rs` — `detail_markdown_keeps_provider_identity_and_uncertainty_visible`
+- `src/render/markdown/article/tests.rs` — `article_markdown_renders_semantic_scholar_and_indexing_sections`
+
+No other test file is authorized.

--- a/sdlc/tickets/drafts/1035-put-the-useful-population-numbers-where-they-can-be-seen.md
+++ b/sdlc/tickets/drafts/1035-put-the-useful-population-numbers-where-they-can-be-seen.md
@@ -1,0 +1,23 @@
+---
+flow: build
+priority: 5
+hold: draft for review; do not promote until Ian releases this
+---
+# Put the useful population numbers where they can be seen
+
+The gnomAD v4 population section renders roughly 130 rows. It includes every HGDP village cohort, some with sample sizes as low as a dozen alleles, and rows whose frequency renders as `-` because no alleles were observed at all. The numbers a clinician actually needs — the overall frequency in each of exomes and genomes, the ancestry group with the highest frequency, the filtering allele frequency, and the quality filter status — are correct and present, and are buried among rows that will not inform any decision.
+
+This is a presentation problem sitting on top of a data path that was verified correct against the gnomAD API on 2026-08-19, so nothing about the underlying values should change.
+
+The detail must remain reachable. Someone studying a specific population needs the village-level cohorts, and removing them would be a real loss. The question is what a reader sees first.
+
+## The hard choice to settle
+
+Decide between showing a summary by default with the full table behind a flag, and keeping the full table but ordering and grouping it so the important rows come first. The first is a better reading experience and changes what a default caller receives; the second changes nothing structurally but does less. Pick one, and say in the design how a caller who wants everything asks for it.
+
+## Done when
+
+- The overall exome and genome frequencies, the highest-frequency ancestry group, the filtering allele frequency, and the quality filter status are visible without scrolling past cohort rows.
+- Every row available today remains reachable through a documented route.
+- Rows where no alleles were observed are distinguishable from rows where the frequency is genuinely zero.
+- The typed JSON form is unchanged, so anything parsing it keeps working.

--- a/sdlc/tickets/drafts/1035-put-the-useful-population-numbers-where-they-can-be-seen.md
+++ b/sdlc/tickets/drafts/1035-put-the-useful-population-numbers-where-they-can-be-seen.md
@@ -1,6 +1,7 @@
 ---
 flow: build
 priority: 5
+deps: ["1022"]
 hold: draft for review; do not promote until Ian releases this
 ---
 # Put the useful population numbers where they can be seen
@@ -21,3 +22,12 @@ Decide between showing a summary by default with the full table behind a flag, a
 - Every row available today remains reachable through a documented route.
 - Rows where no alleles were observed are distinguishable from rows where the frequency is genuinely zero.
 - The typed JSON form is unchanged, so anything parsing it keeps working.
+
+## Existing tests that pin this
+
+Restatement is authorized in `src/render/markdown/variant/tests.rs`, for these tests by name, only to the extent they assert the current row set or row order of the population table:
+
+- `variant_markdown_renders_compact_clinvar_and_population_fields`
+- `variant_population_markdown_keeps_missing_status_compact`
+
+No other test file is authorized. Assertions about the values themselves — the grpmax FAF95 line, the caveat sentence, the quality filter status — must survive, since the data path was verified correct and is not what this ticket changes.

--- a/sdlc/tickets/drafts/1036-stop-the-windows-contract-suite-failing-on-a-live-network-call.md
+++ b/sdlc/tickets/drafts/1036-stop-the-windows-contract-suite-failing-on-a-live-network-call.md
@@ -1,0 +1,24 @@
+---
+flow: build
+priority: 7
+hold: draft for review; do not promote until Ian releases this
+---
+# Stop the Windows contract suite failing on a live network call
+
+`windows_cache_epoch_files_are_user_only_and_reject_hard_links` in `tests/managed_state_permissions.rs` failed CI on 2026-08-19 with a Windows socket error while reading a MyGene request:
+
+```
+repaired MyGene fixture result: "read MyGene request: A non-blocking socket operation
+could not be completed immediately. (os error 10035)"
+```
+
+The identical commit passed on re-run with no change to the tree, so the failure is intermittent rather than a real defect. That is the problem. A test in a deterministic gate is reaching a live external service, which is exactly what `sdlc/planning/verify-lane.md` argues a gate must never do: an unattended run must not be judged on someone else's uptime or on a transient socket condition.
+
+The cost is not one red build. Five of the last twelve CI runs on `main` were red, and a branch that is red this often trains everyone to re-run rather than read, which is how a real failure gets missed. The test's actual subject — that cache files are user-only and reject hard links — has nothing to do with the network.
+
+## Done when
+
+- The test exercises the file permission and hard-link behaviour it is named for, without depending on a live network call succeeding.
+- The test passes repeatedly on Windows without a re-run.
+- Any genuinely live coverage this test was providing is either kept in the verify lane, where live failures are expected and read by a person, or is deliberately dropped with a note saying so.
+- The design states whether other tests in the deterministic gates reach live services, since a single instance and a pattern call for different responses.

--- a/sdlc/tickets/drafts/1036-stop-the-windows-contract-suite-failing-on-a-live-network-call.md
+++ b/sdlc/tickets/drafts/1036-stop-the-windows-contract-suite-failing-on-a-live-network-call.md
@@ -22,3 +22,7 @@ The cost is not one red build. Five of the last twelve CI runs on `main` were re
 - The test passes repeatedly on Windows without a re-run.
 - Any genuinely live coverage this test was providing is either kept in the verify lane, where live failures are expected and read by a person, or is deliberately dropped with a note saying so.
 - The design states whether other tests in the deterministic gates reach live services, since a single instance and a pattern call for different responses.
+
+## Existing tests that pin this
+
+Restatement is authorized in `tests/managed_state_permissions.rs`, for `windows_cache_epoch_files_are_user_only_and_reject_hard_links` by name. This is the case where the test itself is the defect: it reaches a live service to set up a condition unrelated to what it asserts. No other test file is authorized.

--- a/sdlc/tickets/drafts/1037-document-that-expert-assertions-are-germline-only.md
+++ b/sdlc/tickets/drafts/1037-document-that-expert-assertions-are-germline-only.md
@@ -14,6 +14,6 @@ This is the same failure shape as reporting zero for a source that was never rea
 ## Done when
 
 - The command's help states that the source covers germline interpretations.
-- The public documentation for the ClinGen commands states the same, and says where somatic interpretation lives instead.
+- The public documentation for the ClinGen commands states the same, and points a somatic question at CIViC, which BioMCP already serves through `get gene <symbol> civic` and its variant equivalents. Name that as the destination; do not invent or link a source BioMCP does not carry.
 - A reader who arrives with a somatic question can tell from the output or the help that they are asking the wrong source, rather than concluding no evidence exists.
 - No behaviour changes: this ticket adds no filtering, no detection of somatic intent, and no new source.

--- a/sdlc/tickets/drafts/1037-document-that-expert-assertions-are-germline-only.md
+++ b/sdlc/tickets/drafts/1037-document-that-expert-assertions-are-germline-only.md
@@ -1,0 +1,19 @@
+---
+flow: quickfix
+priority: 4
+hold: draft for review; do not promote until Ian releases this
+---
+# Document that expert assertions are germline only
+
+The ClinGen Evidence Repository holds germline variant interpretations made under the ACMG/AMP framework. Somatic tumour variant interpretation uses a different framework entirely, with its own tiers, and lives in different resources. Nothing in `variant erepo`'s help, its documentation, or its empty result says this.
+
+The consequence is a silent wrong answer for a whole class of user. Someone working a somatic oncology case points the command at a tumour variant, gets "No expert assertions were returned," and concludes no expert opinion exists. The command is behaving correctly and the conclusion is wrong, because the question was outside what this source covers.
+
+This is the same failure shape as reporting zero for a source that was never reached: a true statement that leads a reader somewhere false. The fix is words, not behaviour.
+
+## Done when
+
+- The command's help states that the source covers germline interpretations.
+- The public documentation for the ClinGen commands states the same, and says where somatic interpretation lives instead.
+- A reader who arrives with a somatic question can tell from the output or the help that they are asking the wrong source, rather than concluding no evidence exists.
+- No behaviour changes: this ticket adds no filtering, no detection of somatic intent, and no new source.

--- a/sdlc/tickets/drafts/1038-fail-fast-when-a-ci-step-stalls.md
+++ b/sdlc/tickets/drafts/1038-fail-fast-when-a-ci-step-stalls.md
@@ -1,0 +1,37 @@
+---
+flow: build
+priority: 7
+hold: draft for review; do not promote until Ian releases this
+---
+# Fail fast when a CI step stalls
+
+The `canonical-gates` job on CI run 32302143809 ran for six hours and was then cancelled by GitHub's default job limit. It never reached a gate. The whole six hours was spent inside step 7, `Install canonical gate tools`, which started at 21:06:57 and was still running at 03:06:39. Steps 8 through 11 — the lint, test, and specification gates — were skipped. The same job normally finishes in about 25 minutes.
+
+No workflow in `.github/workflows/` sets `timeout-minutes` on any job or step. That is why a stall costs six hours rather than failing in a few minutes with a message.
+
+The step that stalled does several things that can hang on someone else's service: `sudo apt-get update` and an `apt-get install` of four pinned packages, then `cargo install cargo-nextest --locked` and `cargo install cargo-deny --locked`, which compile from source, then two `uv tool install` calls. Any one of those can block indefinitely on a network read.
+
+The release workflow has the same step, at `.github/workflows/release.yml:81`. A release can therefore hang the same way, which matters more than a hung branch build.
+
+The cost is not the runner minutes. It is that a six-hour cancelled job looks, on the checks list, much like a failure — so the response is to re-run rather than to read, and that is the same habit that hides a real failure. Five of the last twelve CI runs on `main` were red, and this run is part of why.
+
+## The hard choice to settle
+
+Decide between putting a time limit on the jobs and steps, removing the from-source builds by installing prebuilt binaries or restoring a cache, and doing both. A time limit alone turns a six-hour hang into a fast red, which is an improvement but still a red build. Removing the source builds shortens the window in which a stall is possible but does not close it. Pick one, apply it consistently to every workflow rather than only the one that failed, and say in the design why.
+
+Whatever limit is chosen must have headroom over the observed honest duration of each job — `canonical-gates` around 25 minutes, `full-features` around 13, `windows-contracts` around 7 — so that a slow-but-working run is not killed. Say where the numbers came from.
+
+## Done when
+
+- A job or step that stops making progress fails within a bounded time instead of running to GitHub's default limit.
+- The bound applies to every job in every workflow under `.github/workflows/`, including the release workflow, not only `canonical-gates`.
+- A run killed by the bound says so in a way that distinguishes it from a gate failure, so a reader can tell a stall from a real red.
+- Normal runs at their observed durations are unaffected.
+
+## Related
+
+`sdlc/tickets/drafts/1036` covers a deterministic Windows test making a live network call. Both are the same underlying complaint — an unattended gate judged on someone else's uptime — but the fixes are unrelated and they touch different files. Neither blocks the other.
+
+## Existing tests that pin this
+
+None. The workflow files are not asserted against by any test in `tests/`. Checked 2026-08-20. No restatement is needed or authorized.


### PR DESCRIPTION
Eight more drafts, all held in `sdlc/tickets/drafts/` with `hold:` lines. Nothing promoted, nothing reaches the board. This closes out every finding from the 2026-08-19 exploratory run plus what the follow-up verification turned up.

| Ticket | Flow | What |
| --- | --- | --- |
| 1030 | build | no way to see the MCP tool catalog without writing a JSON-RPC client |
| 1031 | build | `variant_erepo` schema looser than `search`, breaking typed-catalog uniformity |
| 1032 | build | an empty ClinGen result should say how many assertions the gene has |
| 1033 | quickfix | `gene cspec --version` wants a 90-character IRI |
| 1034 | quickfix | authors and affiliations render as indistinguishable bullets |
| 1035 | build | the useful population numbers are buried under ~130 cohort rows |
| 1036 | build | a deterministic Windows gate fails on a live MyGene socket call |
| 1037 | quickfix | expert assertions are germline only and nothing says so |

## Two worth reading

**1036** is the flake that failed PR #243 and passed on re-run with no change to the tree. A test named `windows_cache_epoch_files_are_user_only_and_reject_hard_links` is failing on `os error 10035` from a live MyGene call — a deterministic gate reaching an external service, which is exactly what `sdlc/planning/verify-lane.md` argues a gate must never do. Five of the last twelve CI runs on `main` were red, and that is what makes a real failure easy to miss.

**1032** exists because of a number worth knowing: the ClinGen Evidence Repository holds 81 assertions for BRCA1 against 16,061 ClinVar records, and 108 for APC against 17,168. Between roughly 0.5% and 5% of a gene’s known variants have an expert assertion, so "No expert assertions were returned" is the ordinary answer, not the exception. Against that rate the blank reads like a broken tool. Naming the gene-level count turns it into a usable fact, and BioMCP already makes the call that produces it.

## Verified, not assumed

The ClinGen behaviour was checked against the Evidence Repository API directly before any of this was filed. BioMCP is relaying it faithfully — ClinGen itself returns HTTP 404 "No records were found" for `CA003404`, and the bare CAid form BioMCP sends is the correct one; the `CAR:`-prefixed form returns 404 for every allele including ones that do resolve. **There is no bug in the API call.** 1032 and 1037 are about what the output says, not what it fetches.