### PR TITLE
Promote 1022-1038 for the 0.9 release

### DIFF
--- a/sdlc/tickets/1022-reach-gnomad-v4-from-an-rsid-instead-of-refusing.md
+++ b/sdlc/tickets/1022-reach-gnomad-v4-from-an-rsid-instead-of-refusing.md
@@ -1,7 +1,6 @@
 ---
 flow: build
-priority: 8
-hold: draft for review; do not promote until Ian releases this
+priority: 18
 ---
 # Reach gnomAD v4 population data from an rsID
 

--- a/sdlc/tickets/1023-stop-printing-zero-counts-for-a-source-that-was-never-reached.md
+++ b/sdlc/tickets/1023-stop-printing-zero-counts-for-a-source-that-was-never-reached.md
@@ -1,7 +1,6 @@
 ---
 flow: build
-priority: 7
-hold: draft for review; do not promote until Ian releases this
+priority: 17
 ---
 # Stop printing zero counts for a source that was never reached
 

--- a/sdlc/tickets/1024-give-the-mcp-tool-catalog-real-headroom-under-its-budget.md
+++ b/sdlc/tickets/1024-give-the-mcp-tool-catalog-real-headroom-under-its-budget.md
@@ -1,8 +1,7 @@
 ---
 flow: build
-priority: 6
+priority: 13
 deps: ["1030"]
-hold: draft for review; do not promote until Ian releases this
 ---
 # Give the MCP tool catalog real headroom under its budget
 

--- a/sdlc/tickets/1025-correct-the-published-tool-catalog-figures.md
+++ b/sdlc/tickets/1025-correct-the-published-tool-catalog-figures.md
@@ -1,7 +1,7 @@
 ---
 flow: quickfix
-priority: 5
-hold: draft for review; do not promote until Ian releases this
+priority: 4
+deps: ["1024"]
 ---
 # Correct the published tool catalog figures
 

--- a/sdlc/tickets/1026-make-gene-cspec-and-variant-erepo-flags-do-what-they-say.md
+++ b/sdlc/tickets/1026-make-gene-cspec-and-variant-erepo-flags-do-what-they-say.md
@@ -1,7 +1,6 @@
 ---
 flow: build
-priority: 4
-hold: draft for review; do not promote until Ian releases this
+priority: 9
 ---
 # Make gene cspec and variant erepo flags do what they say
 

--- a/sdlc/tickets/1027-stop-flag-order-from-silently-changing-a-command.md
+++ b/sdlc/tickets/1027-stop-flag-order-from-silently-changing-a-command.md
@@ -1,7 +1,6 @@
 ---
 flow: build
-priority: 4
-hold: draft for review; do not promote until Ian releases this
+priority: 15
 ---
 # Stop flag order from silently changing a command
 

--- a/sdlc/tickets/1028-do-not-dump-raw-binary-to-a-terminal.md
+++ b/sdlc/tickets/1028-do-not-dump-raw-binary-to-a-terminal.md
@@ -1,7 +1,6 @@
 ---
 flow: build
-priority: 3
-hold: draft for review; do not promote until Ian releases this
+priority: 6
 ---
 # Do not dump raw binary to a terminal
 

--- a/sdlc/tickets/1029-use-one-vocabulary-for-a-sections-outcome.md
+++ b/sdlc/tickets/1029-use-one-vocabulary-for-a-sections-outcome.md
@@ -1,8 +1,7 @@
 ---
 flow: build
-priority: 3
+priority: 11
 deps: ["1022", "1035"]
-hold: draft for review; do not promote until Ian releases this
 ---
 # Use one vocabulary for a section's outcome
 

--- a/sdlc/tickets/1030-let-the-cli-show-the-mcp-tool-catalog.md
+++ b/sdlc/tickets/1030-let-the-cli-show-the-mcp-tool-catalog.md
@@ -1,7 +1,6 @@
 ---
 flow: build
-priority: 7
-hold: draft for review; do not promote until Ian releases this
+priority: 14
 ---
 # Let the CLI show the MCP tool catalog
 

--- a/sdlc/tickets/1031-tighten-the-variant-erepo-typed-schema.md
+++ b/sdlc/tickets/1031-tighten-the-variant-erepo-typed-schema.md
@@ -1,7 +1,6 @@
 ---
 flow: build
-priority: 5
-hold: draft for review; do not promote until Ian releases this
+priority: 10
 ---
 # Tighten the variant erepo typed schema
 

--- a/sdlc/tickets/1032-say-how-many-assertions-a-gene-has-when-a-variant-has-none.md
+++ b/sdlc/tickets/1032-say-how-many-assertions-a-gene-has-when-a-variant-has-none.md
@@ -1,7 +1,6 @@
 ---
 flow: build
-priority: 6
-hold: draft for review; do not promote until Ian releases this
+priority: 16
 ---
 # Say how many assertions a gene has when a variant has none
 
@@ -23,7 +22,7 @@ Take care not to overstate what the count means. It is the number of assertions 
 
 ## Related
 
-`sdlc/tickets/drafts/1023` covers the neighbouring problem of a zero count printed for a source that was never reached. These are different: 1023 is about an unreachable source, this is about a source that answered honestly with nothing.
+`sdlc/tickets/1023` covers the neighbouring problem of a zero count printed for a source that was never reached. These are different: 1023 is about an unreachable source, this is about a source that answered honestly with nothing.
 
 ## Existing tests that pin this
 

--- a/sdlc/tickets/1033-accept-a-short-version-for-gene-cspec.md
+++ b/sdlc/tickets/1033-accept-a-short-version-for-gene-cspec.md
@@ -1,7 +1,6 @@
 ---
 flow: build
-priority: 3
-hold: draft for review; do not promote until Ian releases this
+priority: 7
 ---
 # Accept a short version for gene cspec
 

--- a/sdlc/tickets/1034-separate-authors-from-affiliations-in-article-indexing.md
+++ b/sdlc/tickets/1034-separate-authors-from-affiliations-in-article-indexing.md
@@ -1,7 +1,6 @@
 ---
 flow: quickfix
-priority: 3
-hold: draft for review; do not promote until Ian releases this
+priority: 8
 ---
 # Separate authors from affiliations in article indexing
 

--- a/sdlc/tickets/1035-put-the-useful-population-numbers-where-they-can-be-seen.md
+++ b/sdlc/tickets/1035-put-the-useful-population-numbers-where-they-can-be-seen.md
@@ -1,8 +1,7 @@
 ---
 flow: build
-priority: 5
+priority: 12
 deps: ["1022"]
-hold: draft for review; do not promote until Ian releases this
 ---
 # Put the useful population numbers where they can be seen
 

--- a/sdlc/tickets/1036-stop-the-windows-contract-suite-failing-on-a-live-network-call.md
+++ b/sdlc/tickets/1036-stop-the-windows-contract-suite-failing-on-a-live-network-call.md
@@ -1,7 +1,6 @@
 ---
 flow: build
-priority: 7
-hold: draft for review; do not promote until Ian releases this
+priority: 19
 ---
 # Stop the Windows contract suite failing on a live network call
 

--- a/sdlc/tickets/1037-document-that-expert-assertions-are-germline-only.md
+++ b/sdlc/tickets/1037-document-that-expert-assertions-are-germline-only.md
@@ -1,7 +1,6 @@
 ---
 flow: quickfix
-priority: 4
-hold: draft for review; do not promote until Ian releases this
+priority: 5
 ---
 # Document that expert assertions are germline only
 

--- a/sdlc/tickets/1038-fail-fast-when-a-ci-step-stalls.md
+++ b/sdlc/tickets/1038-fail-fast-when-a-ci-step-stalls.md
@@ -1,7 +1,6 @@
 ---
 flow: build
-priority: 7
-hold: draft for review; do not promote until Ian releases this
+priority: 20
 ---
 # Fail fast when a CI step stalls
 
@@ -30,7 +29,7 @@ Whatever limit is chosen must have headroom over the observed honest duration of
 
 ## Related
 
-`sdlc/tickets/drafts/1036` covers a deterministic Windows test making a live network call. Both are the same underlying complaint — an unattended gate judged on someone else's uptime — but the fixes are unrelated and they touch different files. Neither blocks the other.
+`sdlc/tickets/1036` covers a deterministic Windows test making a live network call. Both are the same underlying complaint — an unattended gate judged on someone else's uptime — but the fixes are unrelated and they touch different files. Neither blocks the other.
 
 ## Existing tests that pin this
 


### PR DESCRIPTION
Promotes seventeen tickets from `drafts/` to the board. `1021` stays a draft — its hold says the replacement documentation generator is not chosen yet, and that is a decision the factory cannot make.

Priority is the run order, because the claim query allows only one active ticket per channel.

| pri | ticket |
|---:|---|
| 20 | 1038 fail fast when a CI step stalls |
| 19 | 1036 stop the Windows suite failing on a live network call |
| 18 | 1022 reach gnomAD v4 from an rsID |
| 17 | 1023 stop printing zero counts for an unreached source |
| 16 | 1032 say how many assertions a gene has |
| 15 | 1027 stop flag order from silently changing a command |
| 14 | 1030 let the CLI show the MCP tool catalog |
| 13 | 1024 give the tool catalog real headroom |
| 12 | 1035 put the useful population numbers where they can be seen |
| 11 | 1029 use one vocabulary for a section's outcome |
| 10 | 1031 tighten the variant erepo typed schema |
| 9 | 1026 make gene cspec and variant erepo flags do what they say |
| 8 | 1034 separate authors from affiliations |
| 7 | 1033 accept a short version for gene cspec |
| 6 | 1028 do not dump raw binary to a terminal |
| 5 | 1037 document that expert assertions are germline only |
| 4 | 1025 correct the published tool catalog figures |

The two CI tickets lead because every ticket behind them lands through the gates they repair.

Dependencies, all consistent with the priorities above: 1030 → 1024 → 1025, and 1022 → 1035 → 1029.

https://claude.ai/code/session_01RmgTZiZHTV7egsG7qPBYCu