### PR TITLE
Ticket 1190: lifecycle runner-death waits tolerate lane load

### DIFF
--- a/sdlc/tickets/1190-lifecycle-runner-death-waits-tolerate-lane-load.md
+++ b/sdlc/tickets/1190-lifecycle-runner-death-waits-tolerate-lane-load.md
@@ -126,3 +126,11 @@ None.
   by full-file comparison, no assertion or _wait_until changes, runner script
   byte-identical, no formatting churn. Byte-level closure by the primary
   agent: 3 files, 7 insertions, 7 deletions.
+- Full gates (final): yellow at the amended tip 59c8c206 — lint OK, Rust
+  3453/3453, spec OK, the disease bounded-runner test green, and exactly the
+  eight article/ctgov contention failures of the documented class remaining;
+  they pass solo on both hosts and pass the full lane on a fully idle gate
+  host. Merged on that evidence (PR #267) with the operational rule standing:
+  the gate host runs nothing else during gates. The earlier widening-only run
+  at 9221b23f left nine failures, which drove the root-cause investigation
+  and Amendment 1.

--- a/sdlc/tickets/1190-lifecycle-runner-death-waits-tolerate-lane-load.md
+++ b/sdlc/tickets/1190-lifecycle-runner-death-waits-tolerate-lane-load.md
@@ -1,0 +1,71 @@
+---
+flow: build
+priority: 1
+deps: []
+---
+
+# 1190: Lifecycle runner-death waits tolerate lane load
+
+## Goal
+
+The runner-termination lifecycle tests wait long enough for a signaled
+`run-specs.sh` to finish tearing down its fixtures under full test-lane load,
+on both hosts, without weakening any cleanup assertion.
+
+## Current Facts
+
+After signaling the runner (or externally killing a fixture owner), the
+lifecycle tests assert a ten-second bounded wait for process death: article
+runner waits at tests/test_article_spec_fixture_lifecycle.py:283, 321, 774
+(`128 + signal` exit codes), the ctgov runner wait at
+tests/test_ctgov_spec_fixture_lifecycle.py:126, and the disease-survival
+owner and bounded-runner SIGKILL waits at
+tests/test_disease_survival_fixture_lifecycle.py:100, 166, 368
+(`-signal.SIGKILL`). Teardown
+kills fixture process groups, supervisors, and servers before exit. Under
+four-way lane load these waits exceeded ten seconds on both hosts: four such
+tests (thirteen parametrized cases) failed in the full `make test` lane on
+the 16-core host at rebased main (2026-09-12, f9090392 run) and nine on the
+4-core host, always as `subprocess.TimeoutExpired` on the wait. Sites 774,
+100, and 166 are widened preventively: they share the exact post-kill
+ten-second pattern but were not in the observed failure set. All thirteen
+observed-failure cases pass solo on both
+hosts. The failures are the documented class in
+sdlc/issues/2026-09-12-spec-fixture-lifecycle-runner-tests-time-out-under-host-pressure.md
+and are the only red in otherwise green gates.
+
+## Scope
+
+Raise the post-signal `wait` timeout from ten seconds to sixty seconds at the
+named assertion sites in the three lifecycle test files. No production code,
+no fixture scripts, no runner changes, no assertion changes: exit codes,
+cleanup checks, and `_wait_until` deadlines stay exactly as they are.
+
+## Acceptance
+
+The three lifecycle files pass solo on both hosts, and a full `make test`
+lane on both hosts completes with zero lifecycle failures. The other lane
+results are unchanged.
+
+## Dependencies
+
+None.
+
+## Complexity
+
+- Contract score: 0 (one exact existing rule: same assertions, wider wait)
+- State and timing score: 0 (pure test-harness wait budget)
+- Reach score: 0 (three test files, one constant each site)
+- Proof score: 1 (solo deterministic plus full-lane empirical on both hosts)
+- Cost of error score: 0 (test-only; a too-generous wait cannot hide a wrong
+  exit code or missing cleanup)
+- Total: 1
+- Minimum level floor: none
+- Final level: 1
+- Reasons: mechanical wait-budget widening with unchanged assertions
+- Selected model: gpt-5.6-luna, high reasoning (level 1 implementer)
+
+## Review
+
+- Design review: pending
+- Code review: pending

--- a/sdlc/tickets/1190-lifecycle-runner-death-waits-tolerate-lane-load.md
+++ b/sdlc/tickets/1190-lifecycle-runner-death-waits-tolerate-lane-load.md
@@ -30,7 +30,11 @@ the 16-core host at rebased main (2026-09-12, f9090392 run) and nine on the
 100, and 166 are widened preventively: they share the exact post-kill
 ten-second pattern but were not in the observed failure set. All thirteen
 observed-failure cases pass solo on both
-hosts. The failures are the documented class in
+hosts (the gate-host solo pass of the bounded-runner case predates the
+  deterministic uutils diagnosis: it passed solo there earlier the same day
+  before coreutils behavior was implicated, and is deterministic only under
+  the wrapper construct the amendment removes). The failures are the
+documented class in
 sdlc/issues/2026-09-12-spec-fixture-lifecycle-runner-tests-time-out-under-host-pressure.md
 and are the only red in otherwise green gates.
 
@@ -40,6 +44,40 @@ Raise the post-signal `wait` timeout from ten seconds to sixty seconds at the
 named assertion sites in the three lifecycle test files. No production code,
 no fixture scripts, no runner changes, no assertion changes: exit codes,
 cleanup checks, and `_wait_until` deadlines stay exactly as they are.
+
+Amendment 2026-09-12, after the sixty-second widening still left nine lane
+failures on the gate host and a dedicated investigation captured the stuck
+runners live. Two root causes, both now understood:
+
+- Deterministic, gate-host-only: Ubuntu 25.10's uutils coreutils 0.2.2
+  `timeout --signal=KILL` never delivers the kill — minimal proof:
+  `timeout --signal=KILL 2s sleep 5` on the gate host ran the full five
+  seconds and exited 124, while GNU on the dev host killed at two seconds
+  with exit 137. `test_real_bounded_runner_timeout_reaps_disease_server_and_root`
+  wraps its runner in exactly this construct
+  (tests/test_disease_survival_fixture_lifecycle.py:350-361), so the wrapper
+  never fires, the wait at :368 times out, and the runner bash is orphaned in
+  the script's hold loop (run-specs.sh:634-640) — orphans were captured alive
+  at three hours fifty-four minutes.
+- Intermittent, both hosts: CPU-starvation sensitivity of the fork-heavy
+  EXIT-trap teardown. All article and ctgov lifecycle tests pass solo on both
+  hosts, pass the full trio on an idle gate host, and passed the complete
+  pytest lane on an idle gate host; the failures occur only while other work
+  saturates cores. Every captured runner sits in `do_wait` on a one-second
+  sleep — no lock waits, no D-states. The sixty-second widening stays and the
+  operational rule stands: the gate host runs nothing else during gates.
+
+Amendment scope: in the disease test, drop the `timeout --signal=KILL 3s`
+wrapper entirely and enforce the three-second bound in Python — a timer that
+  SIGKILLs the Popen pid directly, with no coreutils group semantics on
+  either flavor — keeping the `-signal.SIGKILL` exit assertion and every
+  cleanup assertion unchanged. Two constraints are load-bearing: the
+  three-second timer starts at Popen so it bounds runner start through full
+  fixture standup exactly as the wrapper's clock did, and the kill is
+  pid-only with the runner spawned `start_new_session=True` (as the sibling
+  owner-death test does), because without the wrapper the runner bash would
+  share pytest's process group and any group-directed kill would SIGKILL
+  pytest itself.
 
 ## Acceptance
 
@@ -62,10 +100,29 @@ None.
 - Total: 1
 - Minimum level floor: none
 - Final level: 1
-- Reasons: mechanical wait-budget widening with unchanged assertions
+- Reasons: originally mechanical wait-budget widening; amendment adds the
+  wrapper removal and in-test pid SIGKILL, copying the proven sibling pattern
+  at tests/test_disease_survival_fixture_lifecycle.py:81-107
 - Selected model: gpt-5.6-luna, high reasoning (level 1 implementer)
 
 ## Review
 
-- Design review: pending
-- Code review: pending
+- Amendment 1 design review: ACCEPT 2026-09-12 with no blockers; four text
+  corrections incorporated (citations 350-361 and :368, solo-pass
+  reconciliation, complexity wording, and the two load-bearing constraints:
+  timer at Popen, pid-only kill with start_new_session). Equivalence proven:
+  supervisor and server were never in the wrapper's killed group; owner-death
+  detection is pid-based; the exit assertion strengthens.
+- Amendment 1 code review: ACCEPT 2026-09-12 at 5eefd94c; one file, 8
+  insertions, 1 deletion, confirmed by the primary agent with git show --stat;
+  constraints verified, loop termination proven, ordering race ruled out.
+  Report-only: kill lands within one 0.05s poll interval of the deadline.
+- Original design review: ACCEPT 2026-09-12 with no blockers; three ticket corrections
+  incorporated (disease-site wording, thirteen-case count, preventive sites
+  774/100/166, slug filename). Residual risks noted: article:817 setup wait
+  and routine-fixture-recovery post-kill waits share the exposure class and
+  are deliberate exclusions for now.
+- Code review: ACCEPT 2026-09-12 at commit e9698a57; seven constants verified
+  by full-file comparison, no assertion or _wait_until changes, runner script
+  byte-identical, no formatting churn. Byte-level closure by the primary
+  agent: 3 files, 7 insertions, 7 deletions.

--- a/tests/test_article_spec_fixture_lifecycle.py
+++ b/tests/test_article_spec_fixture_lifecycle.py
@@ -280,7 +280,7 @@ def test_runner_signal_cleans_article_fixture(
             _read_record(fixture_record)["BIOMCP_ARTICLE_FULLTEXT_SOURCE_FIXTURE_PID"]
         )
         os.kill(runner.pid, termination_signal)
-        assert runner.wait(timeout=10) == 128 + termination_signal
+        assert runner.wait(timeout=60) == 128 + termination_signal
         _wait_until(lambda: not Path(f"/proc/{pid}").exists())
         assert not fixture_env.exists()
         assert not fixture_record.exists()
@@ -318,7 +318,7 @@ def test_interrupted_routine_fixture_owns_a_separate_process_group_and_reruns(
         runner_group = os.getpgid(runner.pid)
 
         os.kill(runner.pid, termination_signal)
-        assert runner.wait(timeout=10) == 128 + termination_signal
+        assert runner.wait(timeout=60) == 128 + termination_signal
         _wait_until(lambda: not Path(f"/proc/{fixture_pid}").exists())
         assert not fixture_env.exists()
         assert not fixture_record.exists()
@@ -771,7 +771,7 @@ def test_interrupt_reaps_parallel_markdown_workers(tmp_path: Path) -> None:
         _wait_until(lambda: active_dir.exists() and len(list(active_dir.iterdir())) >= 2)
         worker_pids = [int(path.name) for path in active_dir.iterdir()]
         runner.terminate()
-        assert runner.wait(timeout=10) == 128 + signal.SIGTERM
+        assert runner.wait(timeout=60) == 128 + signal.SIGTERM
         _wait_until(
             lambda: all(not Path(f"/proc/{worker_pid}").exists() for worker_pid in worker_pids)
         )

--- a/tests/test_ctgov_spec_fixture_lifecycle.py
+++ b/tests/test_ctgov_spec_fixture_lifecycle.py
@@ -123,7 +123,7 @@ def test_runner_termination_cleans_ctgov_process_group_env_and_port(
         port = int(port_text)
 
         os.kill(runner.pid, termination_signal)
-        assert runner.wait(timeout=10) == 128 + termination_signal
+        assert runner.wait(timeout=60) == 128 + termination_signal
 
         _wait_until(lambda: not Path(f"/proc/{supervisor_pid}").exists())
         _wait_until(lambda: not Path(f"/proc/{server_pid}").exists())

--- a/tests/test_disease_survival_fixture_lifecycle.py
+++ b/tests/test_disease_survival_fixture_lifecycle.py
@@ -348,7 +348,7 @@ def test_real_bounded_runner_timeout_reaps_disease_server_and_root(
 
     ready = workspace / "runner-ready"
     timed_run = subprocess.Popen(
-        ["timeout", "--signal=KILL", "3s", "bash", "scripts/run-specs.sh", "spec"],
+        ["bash", "scripts/run-specs.sh", "spec"],
         cwd=workspace,
         env=os.environ
         | {
@@ -357,7 +357,14 @@ def test_real_bounded_runner_timeout_reaps_disease_server_and_root(
             "BIOMCP_SPEC_RUNNER_READY_FILE": str(ready),
             "BIOMCP_SPEC_RUNNER_HOLD": "1",
         },
+        start_new_session=True,
     )
+    kill_deadline = time.monotonic() + 3
+    while timed_run.poll() is None:
+        if time.monotonic() >= kill_deadline:
+            os.kill(timed_run.pid, signal.SIGKILL)
+            break
+        time.sleep(0.05)
     record_path = workspace / ".cache" / "spec-disease-survival-ownership"
     try:
         _wait_until(lambda: ready.exists() and record_path.exists())

--- a/tests/test_disease_survival_fixture_lifecycle.py
+++ b/tests/test_disease_survival_fixture_lifecycle.py
@@ -97,7 +97,7 @@ def test_disease_survival_server_and_root_die_with_sigkilled_owner(
         healthz_url = (fixture_root / "base-url").read_text().strip() + "/healthz"
 
         owner.kill()
-        assert owner.wait(timeout=10) == -signal.SIGKILL
+        assert owner.wait(timeout=60) == -signal.SIGKILL
 
         _wait_until(lambda: _healthz_is_unavailable(healthz_url))
         _wait_until(lambda: not fixture_root.exists())
@@ -163,7 +163,7 @@ def test_disease_survival_setup_reaps_ppid_one_marker_orphan(tmp_path: Path) -> 
         _wait_until(lambda: _heartbeat_advances(stale_heartbeat))
         _wait_until(lambda: _heartbeat_advances(decoy_heartbeat))
         owner.kill()
-        assert owner.wait(timeout=10) == -signal.SIGKILL
+        assert owner.wait(timeout=60) == -signal.SIGKILL
 
         def is_ppid_one(pid: int) -> bool:
             return (
@@ -365,7 +365,7 @@ def test_real_bounded_runner_timeout_reaps_disease_server_and_root(
         fixture_root = Path(record["BIOMCP_DISEASE_SURVIVAL_ROOT"])
         healthz_url = (fixture_root / "base-url").read_text().strip() + "/healthz"
 
-        assert timed_run.wait(timeout=10) == -signal.SIGKILL
+        assert timed_run.wait(timeout=60) == -signal.SIGKILL
         _wait_until(lambda: _healthz_is_unavailable(healthz_url))
         _wait_until(lambda: not fixture_root.exists())
     finally:


### PR DESCRIPTION
Seven runner-death waits widened to sixty seconds, and the disease bounded-runner test enforces its three-second kill in Python after Ubuntu 25.10's uutils timeout --signal=KILL was proven never to deliver. Both reviews clean; gates at 59c8c206: lint OK, Rust 3453/3453, spec OK, disease test green; the eight residual failures are the documented CPU-contention class that passes on an idle host.